### PR TITLE
Category service now uses backend

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -3,10 +3,14 @@ import { fireEvent, waitForElement } from '@testing-library/react'
 import { actRender } from './test/utilities'
 import App from './App'
 import restaurantService from './services/restaurant'
+import categoryService from './services/category'
 import { MemoryRouter } from 'react-router-dom'
 
 jest.mock('./services/restaurant.js')
 restaurantService.getAll.mockResolvedValue([])
+
+jest.mock('./services/category.js')
+categoryService.getAll.mockResolvedValue([{ id: 3, name: 'salads' }])
 
 test('randomizer exists initially', async () => {
   const { queryByTestId } = await actRender(

--- a/src/components/AddForm.test.js
+++ b/src/components/AddForm.test.js
@@ -3,10 +3,13 @@ import { fireEvent, wait, waitForElementToBeRemoved } from '@testing-library/rea
 import { actRender } from '../test/utilities'
 import AddForm from './AddForm'
 import restaurantService from '../services/restaurant'
+import categoryService from '../services/category'
 import App from '../App'
 import { MemoryRouter } from 'react-router-dom'
 
 jest.mock('../services/restaurant.js')
+jest.mock('../services/category.js')
+categoryService.getAll.mockResolvedValue([{ id: 3, name: 'salads' }])
 
 beforeEach(() => {
   jest.clearAllMocks()

--- a/src/components/CategoryDropdown.js
+++ b/src/components/CategoryDropdown.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import Dropdown from 'react-bootstrap/Dropdown'
-import categoryService from '../services/categoryServiceStub'
+import categoryService from '../services/category'
 import PropTypes from 'prop-types'
 
 const CategoryDropdown = ({ text, selected, onAdd, onRemove }) => {

--- a/src/components/CategoryDropdown.test.js
+++ b/src/components/CategoryDropdown.test.js
@@ -2,9 +2,9 @@ import React from 'react'
 import { fireEvent, waitForElement } from '@testing-library/react'
 import CategoryDropdown from './CategoryDropdown'
 import { actRender } from '../test/utilities'
-import categoryService from '../services/categoryServiceStub'
+import categoryService from '../services/category'
 
-jest.mock('../services/categoryServiceStub.js')
+jest.mock('../services/category.js')
 const testCategories = [{ id: 1, name: 'pizza' }, { id: 2, name: 'burger' }, { id: 3, name: 'salads' }]
 
 beforeEach(() => {

--- a/src/components/Filter.test.js
+++ b/src/components/Filter.test.js
@@ -1,9 +1,13 @@
 import React from 'react'
 import { fireEvent } from '@testing-library/react'
 import { actRender } from '../test/utilities'
+import categoryService from '../services/category'
 import Filter from './Filter'
 
+jest.mock('../services/category.js')
 const testCategories = [{ id: 1, name: 'pizza' }, { id: 2, name: 'burger' }, { id: 3, name: 'salads' }]
+
+categoryService.getAll.mockResolvedValue([...testCategories])
 
 test('filter list exists', async () => {
   const { queryByTestId } = await actRender(

--- a/src/components/Randomizer.test.js
+++ b/src/components/Randomizer.test.js
@@ -3,6 +3,7 @@ import { fireEvent, waitForDomChange } from '@testing-library/react'
 import { actRender } from '../test/utilities'
 import Randomizer from './Randomizer'
 import restaurantService from '../services/restaurant'
+import categoryService from '../services/category'
 
 jest.mock('../services/restaurant.js')
 restaurantService.getRandom.mockResolvedValue({
@@ -10,6 +11,10 @@ restaurantService.getRandom.mockResolvedValue({
   url: 'www.pizza.fi',
   id: 1
 })
+
+jest.mock('../services/category.js')
+categoryService.getAll.mockResolvedValue([{ id: 3, name: 'salads' }])
+
 
 test('new restaurant button exists', async () => {
   const { queryByTestId } = await actRender(<Randomizer />)

--- a/src/components/RestaurantList.test.js
+++ b/src/components/RestaurantList.test.js
@@ -1,14 +1,17 @@
 import React from 'react'
 import { render, fireEvent, waitForElement, waitForElementToBeRemoved } from '@testing-library/react'
 import restaurantService from '../services/restaurant'
+import categoryService from '../services/category'
 import App from '../App'
 import RestaurantList from './RestaurantList'
 import { MemoryRouter } from 'react-router-dom'
 
 jest.mock('../services/restaurant.js')
+jest.mock('../services/category.js')
 
 beforeEach(() => {
   jest.clearAllMocks()
+  categoryService.getAll.mockResolvedValue([{ id: 3, name: 'salads' }])
   restaurantService.getAll.mockResolvedValue(
     [
       {

--- a/src/services/category.js
+++ b/src/services/category.js
@@ -1,0 +1,11 @@
+import axios from 'axios'
+const baseUrl = '/api/categories'
+
+const getAll = async () => {
+  const response = await axios.get(`${baseUrl}`)
+  return response.data
+}
+
+export default {
+  getAll
+}

--- a/src/services/categoryServiceStub.js
+++ b/src/services/categoryServiceStub.js
@@ -1,9 +1,0 @@
-const list = [{name: 'Asian', id:1}, {name: 'Sushi', id:2}, {name: 'Pizza', id:3}]
-
-const getAll = async () => {
-  return list
-}
-
-export default {
-  getAll
-}


### PR DESCRIPTION
Added communication between the frontend and the `/api/categories`. Fixed tests to use mocked service instead of the stub implementation.