### PR TITLE
Added login form

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@ import Randomizer from './components/Randomizer'
 import AddForm from './components/AddForm'
 import restaurantService from './services/restaurant'
 import RestaurantList from './components/RestaurantList'
+import LoginForm from './components/auth/LoginForm'
 
 const App = () => {
   const navbar = () => {
@@ -37,6 +38,7 @@ const App = () => {
         <Route path="/add" render={() => <AddForm onSubmit={restaurantService.add} />} />
         <Route path="/edit/:id" render={({ match }) => <AddForm id={match.params.id} onSubmit={restaurantService.update} />} />
         <Route path="/restaurants" render={() => <RestaurantList restaurantService={restaurantService} />} />
+        <Route path="/login" render={() => <LoginForm />} />
       </section>
     </>
   )

--- a/src/App.js
+++ b/src/App.js
@@ -1,14 +1,19 @@
 import React from 'react'
 import './App.css'
-import { Route, Link } from 'react-router-dom'
+import { Route, Link, Redirect, useHistory } from 'react-router-dom'
 import { Nav, Navbar } from 'react-bootstrap'
 import Randomizer from './components/Randomizer'
 import AddForm from './components/AddForm'
 import restaurantService from './services/restaurant'
 import RestaurantList from './components/RestaurantList'
 import LoginForm from './components/auth/LoginForm'
+import authService from './services/authentication'
 
 const App = () => {
+  // HACK: Required to ensure triggering state update on every history.push(...) from components
+  // eslint-disable-next-line no-unused-vars
+  const history = useHistory()
+
   const navbar = () => {
     return (
       <Navbar collapseOnSelect bg="light" expand="lg">
@@ -28,6 +33,8 @@ const App = () => {
     )
   }
 
+  const token = authService.getToken()
+  const isLoggedIn = token !== undefined
   return (
     <>
       <header className='main-navbar'>
@@ -38,7 +45,12 @@ const App = () => {
         <Route path="/add" render={() => <AddForm onSubmit={restaurantService.add} />} />
         <Route path="/edit/:id" render={({ match }) => <AddForm id={match.params.id} onSubmit={restaurantService.update} />} />
         <Route path="/restaurants" render={() => <RestaurantList restaurantService={restaurantService} />} />
-        <Route path="/login" render={() => <LoginForm />} />
+        <Route path="/login" render={() => isLoggedIn
+          ? <Redirect to={'/admin'} />
+          : <LoginForm />} />
+        <Route path="/admin" render={() => isLoggedIn
+          ? <span>Admin Control Panel Thing (tm)</span>
+          : <Redirect to={'/login'} />} />
       </section>
     </>
   )

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -4,13 +4,21 @@ import { actRender } from './test/utilities'
 import App from './App'
 import restaurantService from './services/restaurant'
 import categoryService from './services/category'
+import authService from './services/authentication'
 import { MemoryRouter } from 'react-router-dom'
 
 jest.mock('./services/restaurant.js')
-restaurantService.getAll.mockResolvedValue([])
+
+jest.mock('./services/authentication.js')
 
 jest.mock('./services/category.js')
-categoryService.getAll.mockResolvedValue([{ id: 3, name: 'salads' }])
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  authService.getToken.mockReturnValue(undefined)
+  restaurantService.getAll.mockResolvedValue([])
+  categoryService.getAll.mockResolvedValue([{ id: 3, name: 'salads' }])
+})
 
 test('randomizer exists initially', async () => {
   const { queryByTestId } = await actRender(
@@ -70,4 +78,22 @@ test('restaurantList component is rendered when list button is pressed', async (
 
   const list = await waitForElement(() => getByTestId('restaurantList'))
   expect(list).toBeInTheDocument()
+})
+
+describe('when not logged in', () => {
+  test('navigating to /admin redirects to /login', async () => {
+    authService.getToken.mockReturnValue(undefined)
+
+    const { getPath } = await actRender(<App />, ['/admin'])
+    expect(getPath().pathname).toBe('/login')
+  })
+})
+
+describe('when logged in as an administrator', () => {
+  test('navigating to /login redirects to /admin', async () => {
+    authService.getToken.mockReturnValue('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjVlNDUzYmFlNjZiYjNkMjUxZGMwM2U5YyIsInVzZXJuYW1lIjoiTWFrZSIsImlhdCI6MTU4MTU5OTg5MX0.0BDsns4hxWvMguZq8llaB3gMTvPNDkDhPkl7mCYl928')
+
+    const { getPath } = await actRender(<App />, ['/login'])
+    expect(getPath().pathname).toBe('/admin')
+  })
 })

--- a/src/components/AddForm.js
+++ b/src/components/AddForm.js
@@ -64,10 +64,9 @@ const AddForm = ({ id, onSubmit }) => {
       {error ? <Alert data-testid='addForm-errorMessage' variant='danger'>{error}</Alert> : null}
       {restaurant ?
         <Form onSubmit={handleSubmit(saveRestaurant)} className='add-form'>
-          <Form.Group>
+          <Form.Group data-testid='addForm-nameField'>
             <Form.Label>Restaurant Name</Form.Label>
             <Form.Control
-              data-testid='addForm-nameField'
               disabled={!restaurant}
               type='text'
               name='name'
@@ -75,7 +74,7 @@ const AddForm = ({ id, onSubmit }) => {
               onChange={(event) => setName(event.target.value)}
               ref={register({ required: true, minLength: 3, maxLength: 240 })} />
             {errors.name &&
-              <Alert data-testid='addForm-nameErrorMessage' variant='danger'>
+              <Alert variant='danger'>
                 {errors.name.type === 'required' && <li>Name cannot be empty!</li>}
                 {errors.name.type === 'minLength' && <li>Must be at least 3 characters</li>}
                 {errors.name.type === 'maxLength' && <li>Must be shorter than 240 characters</li>}
@@ -83,18 +82,17 @@ const AddForm = ({ id, onSubmit }) => {
             }
           </Form.Group>
 
-          <Form.Group>
+          <Form.Group data-testid='addForm-urlField'>
             <Form.Label>Restaurant Website</Form.Label>
             <Form.Control
               disabled={!restaurant}
-              data-testid='addForm-urlField'
               type='text'
               name='url'
               defaultValue={restaurant.url}
               onChange={(event) => setUrl(event.target.value)}
               ref={register({ required: true, minLength: 3, maxLength: 240 })} />
             {errors.url &&
-              <Alert data-testid='addForm-urlErrorMessage' variant='danger'>
+              <Alert variant='danger'>
                 {errors.url.type === 'required' && <li>URL cannot be empty!</li>}
                 {errors.url.type === 'minLength' && <li>Must be at least 3 characters</li>}
                 {errors.url.type === 'maxLength' && <li>Must be shorter than 240 characters</li>}

--- a/src/components/AddForm.test.js
+++ b/src/components/AddForm.test.js
@@ -24,13 +24,13 @@ describe('form alerts', () => {
       </MemoryRouter>
     )
 
-    const { queryByRole } = within(await queryByTestId('addForm-nameField'))
+    const { queryByRole } = within(queryByTestId('addForm-nameField'))
     const error = queryByRole(/alert/i)
     expect(error).not.toBeInTheDocument()
   })
 
   test('invalid name input displays an error message', async () => {
-    const { queryByTestId, getByTestId } = await actRender(
+    const { queryByTestId } = await actRender(
       <MemoryRouter initialEntries={['/add']}>
         <AddForm onSubmit={jest.fn()} />
       </MemoryRouter>
@@ -39,9 +39,7 @@ describe('form alerts', () => {
     const buttonElement = await queryByTestId('addForm-addButton')
     fireEvent.click(buttonElement)
 
-    const nameField = await waitForElement(() => getByTestId('addForm-nameField'))
-    const { getByRole } = within(nameField)
-    const error = getByRole(/alert/i)
+    const error = await waitForElement(() => within(queryByTestId('addForm-nameField')).getByRole(/alert/i))
     expect(error).toBeInTheDocument()
   })
 
@@ -52,13 +50,13 @@ describe('form alerts', () => {
       </MemoryRouter>
     )
 
-    const { queryByRole } = within(await queryByTestId('addForm-urlField'))
+    const { queryByRole } = within(queryByTestId('addForm-urlField'))
     const error = queryByRole(/alert/i)
     expect(error).not.toBeInTheDocument()
   })
 
   test('invalid url input displays an error message', async () => {
-    const { queryByTestId, getByTestId } = await actRender(
+    const { queryByTestId } = await actRender(
       <MemoryRouter initialEntries={['/add']}>
         <AddForm onSubmit={jest.fn()} />
       </MemoryRouter>
@@ -67,9 +65,7 @@ describe('form alerts', () => {
     const buttonElement = await queryByTestId('addForm-addButton')
     fireEvent.click(buttonElement)
 
-    const urlField = await waitForElement(() => getByTestId('addForm-urlField'))
-    const { getByRole } = within(urlField)
-    const error = getByRole(/alert/i)
+    const error = await waitForElement(() => within(queryByTestId('addForm-urlField')).getByRole(/alert/i))
     expect(error).toBeInTheDocument()
   })
 })

--- a/src/components/AddForm.test.js
+++ b/src/components/AddForm.test.js
@@ -113,19 +113,13 @@ test('form is closed after adding a restaurant', async () => {
 })
 
 test('pressing cancel hides the component', async () => {
-  let path
-  const { queryByTestId } = await actRender(
-    <MemoryRouter initialEntries={['/add']}>
-      <AddForm onSubmit={jest.fn()} />
-      <Route path='*' render={({ location }) => { path = location; return null }} />
-    </MemoryRouter>
-  )
+  const { queryByTestId, getPath } = await actRender(<AddForm onSubmit={jest.fn()} />, ['/add'])
 
   // Hide the form
   const buttonElement = queryByTestId('addForm-cancelButton')
   fireEvent.click(buttonElement)
 
-  await wait(() => expect(path.pathname).toBe('/'))
+  await wait(() => expect(getPath().pathname).toBe('/'))
 })
 
 test('form is empty if restaurant is not found with the given id parameter', async () => {

--- a/src/components/auth/LoginForm.js
+++ b/src/components/auth/LoginForm.js
@@ -1,21 +1,22 @@
 import React, { useState } from 'react'
 import { Form, Button, Alert } from 'react-bootstrap'
+import { useHistory } from 'react-router-dom'
 import authService from '../../services/authentication'
 
 const LoginForm = () => {
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
+  const history = useHistory()
 
   const handleLogin = async (event) => {
     event.preventDefault()
     try {
       await authService.login(username, password)
+      history.push('/admin')
     } catch (error) {
       setError(error.message)
     }
-
-    // ERROR HANDLING & MESSAGES
   }
 
   return (

--- a/src/components/auth/LoginForm.js
+++ b/src/components/auth/LoginForm.js
@@ -1,37 +1,41 @@
 import React, { useState } from 'react'
-import { Form, Button } from 'react-bootstrap'
+import { Form, Button, Alert } from 'react-bootstrap'
 import authService from '../../services/authentication'
 
 const LoginForm = () => {
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
 
   const handleLogin = async (event) => {
     event.preventDefault()
-    const response = await authService.login(username, password)
-    
+    try {
+      await authService.login(username, password)
+    } catch (error) {
+      setError(error.message)
+    }
+
     // ERROR HANDLING & MESSAGES
   }
 
   return (
     <>
       <Form onSubmit={handleLogin}>
-        <Form.Group>
-          <Form.Label data-testid='loginform-usernameLabel'>Username</Form.Label>
+        <Form.Group data-testid='loginform-usernameField'>
+          <Form.Label >Username</Form.Label>
           <Form.Control
-            data-testid='loginform-usernameField'
             type='text'
             onChange={(event) => setUsername(event.target.value)}
             placeholder='Your Username' />
         </Form.Group>
-        <Form.Group>
-          <Form.Label data-testid='loginform-passwordLabel'>Password</Form.Label>
+        <Form.Group data-testid='loginform-passwordField'>
+          <Form.Label>Password</Form.Label>
           <Form.Control
-            data-testid='loginform-passwordField'
             type='password'
-            onChange={(event) => {setPassword(event.target.value)}}
+            onChange={(event) => { setPassword(event.target.value) }}
             placeholder='****************' />
         </Form.Group>
+        {error && <Alert data-testid='loginForm-error' variant='danger'>Invalid username or password! </Alert>}
         <Button data-testid='loginform-loginButton' type='submit'>Log In</Button>
       </Form>
     </>

--- a/src/components/auth/LoginForm.js
+++ b/src/components/auth/LoginForm.js
@@ -1,0 +1,41 @@
+import React, { useState } from 'react'
+import { Form, Button } from 'react-bootstrap'
+import authService from '../../services/authentication'
+
+const LoginForm = () => {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+
+  const handleLogin = async (event) => {
+    event.preventDefault()
+    const response = await authService.login(username, password)
+    
+    // ERROR HANDLING & MESSAGES
+  }
+
+  return (
+    <>
+      <Form onSubmit={handleLogin}>
+        <Form.Group>
+          <Form.Label data-testid='loginform-usernameLabel'>Username</Form.Label>
+          <Form.Control
+            data-testid='loginform-usernameField'
+            type='text'
+            onChange={(event) => setUsername(event.target.value)}
+            placeholder='Your Username' />
+        </Form.Group>
+        <Form.Group>
+          <Form.Label data-testid='loginform-passwordLabel'>Password</Form.Label>
+          <Form.Control
+            data-testid='loginform-passwordField'
+            type='password'
+            onChange={(event) => {setPassword(event.target.value)}}
+            placeholder='****************' />
+        </Form.Group>
+        <Button data-testid='loginform-loginButton' type='submit'>Log In</Button>
+      </Form>
+    </>
+  )
+}
+
+export default LoginForm

--- a/src/components/auth/LoginForm.test.js
+++ b/src/components/auth/LoginForm.test.js
@@ -1,0 +1,91 @@
+import React from 'react'
+import { fireEvent, wait, waitForElement, waitForDomChange } from '@testing-library/react'
+import { actRender } from '../../test/utilities'
+import LoginForm from './LoginForm'
+import authService from '../../services/authentication'
+import { MemoryRouter, Route } from 'react-router-dom'
+import { fail } from 'assert'
+
+jest.mock('../../services/authentication.js')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('form is rendered', () => {
+  test('labels for username and password are rendered', async () => {
+    const { queryByTestId } = await actRender(
+      <MemoryRouter initialEntries={['/login']}>
+        <LoginForm />
+      </MemoryRouter>
+    )
+
+    const usernameLabel = queryByTestId('loginform-usernameLabel')
+    expect(usernameLabel).toBeInTheDocument()
+    const passwordLabel = queryByTestId('loginform-passwordLabel')
+    expect(passwordLabel).toBeInTheDocument()
+  })
+
+  test('field for username is rendered', async () => {
+    const { queryByTestId } = await actRender(
+      <MemoryRouter initialEntries={['/login']}>
+        <LoginForm />
+      </MemoryRouter>
+    )
+
+    const userNameField = queryByTestId('loginform-usernameField')
+    expect(userNameField).toBeInTheDocument()
+  })
+
+  test('field for password is rendered', async () => {
+    const { queryByTestId } = await actRender(
+      <MemoryRouter initialEntries={['/login']}>
+        <LoginForm />
+      </MemoryRouter>
+    )
+
+    const passwordField = queryByTestId('loginform-passwordField')
+    expect(passwordField).toBeInTheDocument()
+  })
+
+  test('login button is rendered', async () => {
+    const { queryByTestId } = await actRender(
+      <MemoryRouter initialEntries={['/login']}>
+        <LoginForm />
+      </MemoryRouter>
+    )
+
+    const loginButton = queryByTestId('loginform-loginButton')
+    expect(loginButton).toBeInTheDocument()
+  })
+})
+
+test('clicking the login button calls the authentication service with the inputted username and password', async () => {
+  const { queryByTestId } = await actRender(
+    <MemoryRouter initialEntries={['/login']}>
+      <LoginForm />
+    </MemoryRouter>
+  )
+
+  const userNameField = queryByTestId('loginform-usernameField')
+  fireEvent.change(userNameField, { target: { value: 'PostItMaster' } })
+
+  const passwordField = queryByTestId('loginform-passwordField')
+  fireEvent.change(passwordField, { target: { value: 'TheSecurestPassword' } })
+
+  const loginButton = queryByTestId('loginform-loginButton')
+  fireEvent.click(loginButton)
+  expect(authService).toBeCalledWith('PostItMaster', 'TheSecurestPassword')
+})
+
+test('error message is shown if login fails', async () => {
+  fail('not implemented')
+})
+
+test('token remains undefined if login fails', () => {
+  fail('not implemented')
+})
+
+test('clicking the login button calls the authentication service with the inputted username and password', () => {
+  fail('not implemented')
+})

--- a/src/components/auth/LoginForm.test.js
+++ b/src/components/auth/LoginForm.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { fireEvent, waitForElement } from '@testing-library/react'
+import { fireEvent, wait, waitForElement } from '@testing-library/react'
 import { within } from '@testing-library/dom'
 import { actRender } from '../../test/utilities'
 import LoginForm from './LoginForm'
@@ -80,11 +80,7 @@ test('clicking the login button calls the authentication service with the inputt
 })
 
 test('error message is shown if login fails', async () => {
-  const { queryByTestId, getByTestId } = await actRender(
-    <MemoryRouter initialEntries={['/login']}>
-      <LoginForm onSubmit={jest.fn()} />
-    </MemoryRouter>
-  )
+  const { queryByTestId, getByTestId } = await actRender(<LoginForm onSubmit={jest.fn()} />, ['/login'])
 
   authService.login.mockRejectedValue({ message: 'foobar' })
 
@@ -93,4 +89,15 @@ test('error message is shown if login fails', async () => {
 
   const error = await waitForElement(() => getByTestId(/loginForm-error/i))
   expect(error).toBeInTheDocument()
+})
+
+test('user is redirected to /admin on succesfull login', async () => {
+  const { queryByTestId, getPath } = await actRender(<LoginForm onSubmit={jest.fn()} />, ['/login'])
+
+  authService.login.mockResolvedValue()
+
+  const buttonElement = await queryByTestId(/loginForm-loginButton/i)
+  fireEvent.click(buttonElement)
+
+  await wait(() => expect(getPath().pathname).toBe('/admin'))
 })

--- a/src/test/utilities.js
+++ b/src/test/utilities.js
@@ -1,9 +1,17 @@
+import React from 'react'
 import { act, render } from '@testing-library/react'
+import { Route, MemoryRouter } from 'react-router-dom'
 
-export const actRender = async (element) => {
+export const actRender = async (element, initialEntries) => {
   let queryByTestId, getByTestId, queryAllByTestId, getAllByTestId, getByText, queryByText, getAllByText
+  let path
   await act(async () => {
-    const renderResult = render(element)
+    const renderResult = render(
+      <MemoryRouter initialEntries={initialEntries}>
+        {element}
+        <Route path='*' render={({ location }) => { path = location; return null }} />
+      </MemoryRouter>
+    )
     queryByTestId = renderResult.queryByTestId
     queryByTestId = renderResult.queryByTestId
     getByTestId = renderResult.getByTestId
@@ -14,5 +22,5 @@ export const actRender = async (element) => {
     getAllByText = renderResult.getAllByText
   })
 
-  return { queryByTestId, getByTestId, queryAllByTestId, getAllByTestId, getByText, queryByText, getAllByText }
+  return { queryByTestId, getByTestId, queryAllByTestId, getAllByTestId, getByText, queryByText, getAllByText, getPath: () => path }
 }


### PR DESCRIPTION
- Login form on path `/login`
- Placeholder route for `/admin`
- `/admin` redirects to `/login` when not logged in
- `/login` redirects to `/admin` when logged in
- Login form sets the auth token via the `authService` on succesfull login
- `actRender` test utility method now supports getting history path (current url) via `getPath`-getter