### PR TITLE
REMOVE & PUT calls to /api/restaurants now remove related suggestions

### DIFF
--- a/packages/backend/src/controllers/restaurants.js
+++ b/packages/backend/src/controllers/restaurants.js
@@ -48,9 +48,6 @@ const removeRestaurantFromCategories = async (restaurantId, categoryIds) => {
 const tryRemoveSuggestionsByRestaurant = async (restaurantId) => {
   const removedSuggestions = await Suggestion.deleteMany({ 'data._id': { $eq: restaurantId } })
 
-  if (!removedSuggestions) {
-    return null
-  }
 
   return removedSuggestions
 }

--- a/packages/backend/src/controllers/suggestions.js
+++ b/packages/backend/src/controllers/suggestions.js
@@ -30,7 +30,7 @@ const parseSuggestion = (body, type) => {
   return parsed
 }
 
-// add restaurant
+// suggest to add a restaurant
 suggestionsRouter.post('/add', async (request, response, next) => {
   try {
     const suggestion = await new Suggestion(parseSuggestion(request.body, 'ADD')).save()
@@ -41,7 +41,7 @@ suggestionsRouter.post('/add', async (request, response, next) => {
   }
 })
 
-// remove restaurant
+// suggest to remove a restaurant
 suggestionsRouter.post('/remove', async (request, response, next) => {
   try {
     if (request.body.id) {
@@ -78,8 +78,7 @@ suggestionsRouter.post('/approve/:id', async (request, response, next) => {
     } else if (suggestion.type === 'REMOVE') {
       const restaurant = suggestion.data.toJSON()
       await tryRemoveRestaurant(restaurant.id)
-      await Suggestion.findByIdAndRemove(id)
-
+      
       return response.status(204).end()
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7727,7 +7727,7 @@ node-notifier@^5.4.2:
     shellwords "^0.1.1"
     which "^1.3.0"
 
-node-pre-gyp@*, node-pre-gyp@0.14.0:
+node-pre-gyp@0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
   integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==


### PR DESCRIPTION
- New helper methods 
  -`tryRemoveSuggestionsByRestaurant` so that all suggestions related to a restaurant that's being deleted or updates are removed altogether
  -`tryUpdateRestaurant` to be used in the future update suggestion feature
