### PR TITLE
Fixed backend handling malformed auth tokens incorrectly

### DIFF
--- a/packages/backend/src/util/authorization.js
+++ b/packages/backend/src/util/authorization.js
@@ -9,10 +9,12 @@ const getTokenFromHeaders = (request) => {
 }
 
 const getTokenFromRequest = (request) => {
-  const token = getTokenFromHeaders(request)
-  return token
-    ? jwt.verify(token, config.jwtSecret)
-    : null
+  try {
+    const token = getTokenFromHeaders(request)
+    return jwt.verify(token, config.jwtSecret)
+  } catch (_) {
+    return null
+  }
 }
 
 const requireAuthorized = (request) => {


### PR DESCRIPTION
There was an oversight where malformed tokens could get passed to the `jwt.verify(...)` and cause `authorization.requireAuthorized()` to fail unexpectedly. One example of malformed token causing status 500 was `bearer undefined`. 

Changed the behavior so that all tokens get passed to `jwt.verify(...)` without checking for `undefined`. If verify throws, `null` is returned. This should ensure correct behavior in all cases.