### PR TITLE
Functionality for suggesting edits to restaurants

### DIFF
--- a/documentation/api/suggestions.md
+++ b/documentation/api/suggestions.md
@@ -59,14 +59,15 @@ Returns the added *suggestion* as the response body.
     - `categories`: optional, must be an array containing zero or more category IDs. IDs must be valid ObjectIDs.
 
 
-`POST /api/suggestions/remove`
+`POST /api/suggestions/edit`
 ---------------------------
-Creates a new suggestion for removing a restaurant.
+Creates a new suggestion for editing a restaurant.
 
 ### Request
-Accepts a *restaurant* json-object, without ID and with `categories` replaced with an array of category IDs.
+Accepts a *restaurant* json-object, with ID and with `categories` replaced with an array of category IDs.
 ```js
 {
+  id: string,
   name: string,
   url?: string,
   categories: [
@@ -88,6 +89,43 @@ Returns the added *suggestion* as the response body.
 ### Errors
  - `Status: 400 Bad Request` - if any of the required properties is not provided
  - `Status: 400 Bad Request` - if any of the properties fail to validate
+    - `id`: required, must be a valid id referring to an existing restaurant in the database
+    - `name`: required, must be string and within 3 to 240 characters long.
+    - `url`: must be undefined or a string within 3 to 240 characters long.
+    - `categories`: optional, must be an array containing zero or more category IDs. IDs must be valid ObjectIDs.
+
+
+`POST /api/suggestions/remove`
+---------------------------
+Creates a new suggestion for removing a restaurant.
+
+### Request
+Accepts a *restaurant* json-object, with ID and with `categories` replaced with an array of category IDs.
+```js
+{
+  id: string,
+  name: string,
+  url?: string,
+  categories: [
+    CategoryID_1,
+    CategoryID_2,
+    ...
+  ],
+}
+```
+
+### Response
+| Header         | value              |
+| -------------- | ------------------ |
+| `Content-Type` | `application/json` |
+| `Status Code`  | `201 Created`      |
+
+Returns the added *suggestion* as the response body.
+
+### Errors
+ - `Status: 400 Bad Request` - if any of the required properties is not provided
+ - `Status: 400 Bad Request` - if any of the properties fail to validate
+    - `id`: required, must be a valid id referring to an existing restaurant in the database
     - `name`: required, must be string and within 3 to 240 characters long.
     - `url`: must be undefined or a string within 3 to 240 characters long.
     - `categories`: optional, must be an array containing zero or more category IDs. IDs must be valid ObjectIDs.
@@ -105,11 +143,20 @@ Approves a suggestion with the given `id`. Requires authentication.
 
 Returns the created *restaurant* as the response body.
 
+### Response - Edit-request
+| Header         | value              |
+| -------------- | ------------------ |
+| `Content-Type` | `application/json` |
+| `Status Code`  | `200 OK`           |
+
 ### Response - Remove-request
 | Header         | value              |
 | -------------- | ------------------ |
 | `Content-Type` | `application/json` |
 | `Status Code`  | `204 No Content`   |
+
+### Errors
+ - `Status: 404 Not Found` - if no suggestion is found with the given id or if the suggestion type does not match the existing ones (`ADD` / `EDIT` / `REMOVE`)
 
 
 `POST /api/suggestions/reject/:id`

--- a/packages/app/src/App.js
+++ b/packages/app/src/App.js
@@ -54,9 +54,7 @@ const App = () => {
 
           <Route exact path="/" render={() => <Randomizer />} />
           <Route exact path="/add" render={() => <AddForm key={window.location} onSubmit={isLoggedIn ? restaurantService.add : suggestionService.addRestaurant} />} />
-          <Route exact path="/edit/:id" render={({ match }) => isLoggedIn
-            ? <AddForm key={window.location} id={match.params.id} onSubmit={restaurantService.update} />
-            : <Redirect to={'/login'} />} />
+          <Route exact path="/edit/:id" render={({ match }) => <AddForm key={window.location} id={match.params.id} onSubmit={isLoggedIn ? restaurantService.update : suggestionService.editRestaurant} />} />
           <Route exact path="/restaurants" render={() => <RestaurantList />} />
           <Route exact path="/login" render={() => isLoggedIn
             ? <Redirect to={'/admin/suggestions'} />

--- a/packages/app/src/components/Filter/FilterList/FilterList.js
+++ b/packages/app/src/components/Filter/FilterList/FilterList.js
@@ -10,7 +10,7 @@ const FilterList = ({ selected, onRemove, emptyMessage }) => {
 
   return (
     <span data-testid='filter-list' className='category-list'>
-      {selected.length > 0
+      {selected && selected.length > 0
         ? selected.map((category) =>
           <Badge
             className='entry'
@@ -18,7 +18,7 @@ const FilterList = ({ selected, onRemove, emptyMessage }) => {
             data-testid='filter-listEntry'
             key={category.id}>
             <span>{category.name}</span>
-            <button data-testid='filter-listEntry-deleteButton' onClick={removeHandler(category.id)}>×</button>
+            {onRemove && <button data-testid='filter-listEntry-deleteButton' onClick={removeHandler(category.id)}>×</button>}
           </Badge>
         )
         : <span data-testid='filter-emptyMessage'>{emptyMessage}</span>

--- a/packages/app/src/components/Restaurants/RestaurantList/RestaurantList.js
+++ b/packages/app/src/components/Restaurants/RestaurantList/RestaurantList.js
@@ -53,7 +53,7 @@ const RestaurantList = () => {
             key={restaurant.id}
             item={restaurant}
             onClickRemove={removeRestaurant}
-            onClickEdit={isLoggedIn ? editRestaurant : undefined}
+            onClickEdit={editRestaurant}
           />
         }
       />

--- a/packages/app/src/components/suggestionlist/SuggestionList.css
+++ b/packages/app/src/components/suggestionlist/SuggestionList.css
@@ -8,8 +8,13 @@
 }
 
 .suggestion-entry > .card-header.ADD {
-    background-color: #19e3b1;
+    background-color: #9bcd65;
 }
+
 .suggestion-entry > .card-header.REMOVE {
-    background-color: #ff0066;
+    background-color: #ed5351;
+}
+
+.suggestion-entry > .card-header.EDIT {
+    background-color: #faa629;
 }

--- a/packages/app/src/components/suggestionlist/SuggestionList.js
+++ b/packages/app/src/components/suggestionlist/SuggestionList.js
@@ -1,13 +1,15 @@
 import React, { useState, useEffect } from 'react'
-import { Button, Alert, Card } from 'react-bootstrap'
+import List from '../List/List'
+import { Button, Alert, Card, Table } from 'react-bootstrap'
 import { Link } from 'react-router-dom'
 import PropTypes from 'prop-types'
 import suggestionService from '../../services/suggestion'
+import restaurantService from '../../services/restaurant'
+import categoryService from '../../services/category'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons'
 
 import './SuggestionList.css'
-import List from '../List/List'
 
 export const SuggestionList = () => {
   const [suggestions, setSuggestions] = useState()
@@ -45,16 +47,60 @@ export const SuggestionList = () => {
 }
 
 export const SuggestionEntry = ({ suggestion, handleApprove, handleReject }) => {
+  const [restaurant, setRestaurant] = useState()
+  const [updatedRestaurant, setUpdatedRestaurant] = useState()
+
+  useEffect(() => {
+    if (suggestion.type === 'EDIT' || suggestion.type === 'REMOVE') {
+      restaurantService.getOneById(suggestion.data.id).then(setRestaurant)
+    }
+
+    const mapCategories = async () => {
+      const categories = await categoryService.getAll()
+      const suggestedCategories = categories.filter((c) => suggestion.data.categories.includes(c.id))
+      suggestion.type === 'EDIT'
+        ? setUpdatedRestaurant({ ...suggestion.data, categories: suggestedCategories })
+        : setRestaurant({ ...suggestion.data, categories: suggestedCategories })
+    }
+
+    mapCategories()
+  }, [suggestion])
+
   return (
     <Card className='suggestion-entry' data-testid='suggestionList-entry'>
       <Card.Header className={suggestion.type} >{suggestion.type}</Card.Header>
       <Card.Body>
-        <Card.Title>{suggestion.data.name}</Card.Title>
-        <Card.Subtitle>
-          <a href={suggestion.data.url}>
-            <span>{suggestion.data.url} <FontAwesomeIcon icon={faExternalLinkAlt} /></span>
-          </a>
-        </Card.Subtitle>
+        <Card.Title>{restaurant && restaurant.name}</Card.Title>
+      </Card.Body>
+      <Card.Body>
+        {restaurant &&
+          <Table striped bordered responsive='sm' size='sm'>
+            <thead>
+              <tr>
+                <th>Attribute</th>
+                {updatedRestaurant ? <th>Current</th> : <th>Value</th>}
+                {updatedRestaurant && <th>Suggested</th>}
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Name</td>
+                <td>{restaurant.name}</td>
+                {updatedRestaurant && <td>{updatedRestaurant.name}</td>}
+              </tr>
+              <tr>
+                <td>URL</td>
+                <td><a href={restaurant.url}><span>{restaurant.url} <FontAwesomeIcon icon={faExternalLinkAlt} /></span></a></td>
+                {updatedRestaurant && <td><a href={updatedRestaurant.url}><span>{updatedRestaurant.url} <FontAwesomeIcon icon={faExternalLinkAlt} /></span></a></td>}
+              </tr>
+              <tr>
+                <td>Categories</td>
+                <td>{restaurant.categories.map((category) => <span key={category.id}>{category.name}, </span>)}</td>
+                {updatedRestaurant && <td>{updatedRestaurant.categories.map((category) => <span key={category.id}>{category.name}, </span>)}</td>}
+              </tr>
+            </tbody>
+          </Table>
+        }
       </Card.Body>
       <Card.Body className='buttons'>
         <Button

--- a/packages/app/src/components/suggestionlist/SuggestionList.js
+++ b/packages/app/src/components/suggestionlist/SuggestionList.js
@@ -51,9 +51,22 @@ export const SuggestionEntry = ({ suggestion, handleApprove, handleReject }) => 
   const [updatedRestaurant, setUpdatedRestaurant] = useState()
 
   useEffect(() => {
+
+    /* If the suggestion concerns an existing restaurant */
     if (suggestion.type === 'EDIT' || suggestion.type === 'REMOVE') {
-      restaurantService.getOneById(suggestion.data.id).then(setRestaurant)
+      const findExistingRestaurant = async () => {
+        const found = await restaurantService.getOneById(suggestion.data.id)
+        setRestaurant(found)
+      }
+
+      findExistingRestaurant()
     }
+
+    /**
+    * The restaurant within the given suggestion contains a list of category ids.
+    * To display the names of these categories, we need to fetch them
+    * from the database.
+    */
 
     const mapCategories = async () => {
       const categories = await categoryService.getAll()
@@ -68,40 +81,46 @@ export const SuggestionEntry = ({ suggestion, handleApprove, handleReject }) => 
 
   return (
     <Card className='suggestion-entry' data-testid='suggestionList-entry'>
-      <Card.Header className={suggestion.type} >{suggestion.type}</Card.Header>
-      <Card.Body>
-        <Card.Title>{restaurant && restaurant.name}</Card.Title>
-      </Card.Body>
-      <Card.Body>
-        {restaurant &&
-          <Table striped bordered responsive='sm' size='sm'>
-            <thead>
-              <tr>
-                <th>Attribute</th>
-                {updatedRestaurant ? <th>Current</th> : <th>Value</th>}
-                {updatedRestaurant && <th>Suggested</th>}
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>Name</td>
-                <td>{restaurant.name}</td>
-                {updatedRestaurant && <td>{updatedRestaurant.name}</td>}
-              </tr>
-              <tr>
-                <td>URL</td>
-                <td><a href={restaurant.url}><span>{restaurant.url} <FontAwesomeIcon icon={faExternalLinkAlt} /></span></a></td>
-                {updatedRestaurant && <td><a href={updatedRestaurant.url}><span>{updatedRestaurant.url} <FontAwesomeIcon icon={faExternalLinkAlt} /></span></a></td>}
-              </tr>
-              <tr>
-                <td>Categories</td>
-                <td>{restaurant.categories.map((category) => <span key={category.id}>{category.name}, </span>)}</td>
-                {updatedRestaurant && <td>{updatedRestaurant.categories.map((category) => <span key={category.id}>{category.name}, </span>)}</td>}
-              </tr>
-            </tbody>
-          </Table>
-        }
-      </Card.Body>
+      <Card.Header data-testid='suggestionEntry-type' className={suggestion.type} >{suggestion.type}</Card.Header>
+      {restaurant &&
+        <>
+          <Card.Body>
+            <Card.Title data-testid='suggestionEntry-restaurantName'>{restaurant && restaurant.name}</Card.Title>
+          </Card.Body>
+          <Card.Body>
+            <Table striped bordered responsive='sm' size='sm'>
+              <thead>
+                <tr>
+                  <th>Attribute</th>
+                  {updatedRestaurant ? <th>Current</th> : <th>Value</th>}
+                  {updatedRestaurant &&
+                    <th data-testid='suggestionEntry-updated-th'>Suggested</th>}
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Name</td>
+                  <td>{restaurant.name}</td>
+                  {updatedRestaurant &&
+                    <td data-testid='suggestionEntry-updated-restaurantName'>{updatedRestaurant.name}</td>}
+                </tr>
+                <tr>
+                  <td>URL</td>
+                  <td><a href={restaurant.url}><span>{restaurant.url} <FontAwesomeIcon icon={faExternalLinkAlt} /></span></a></td>
+                  {updatedRestaurant &&
+                    <td data-testid='suggestionEntry-updated-restaurantUrl'><a href={updatedRestaurant.url}><span>{updatedRestaurant.url} <FontAwesomeIcon icon={faExternalLinkAlt} /></span></a></td>}
+                </tr>
+                <tr>
+                  <td>Categories</td>
+                  <td>{restaurant.categories.map((category) => <span key={category.id}>{category.name}, </span>)}</td>
+                  {updatedRestaurant &&
+                    <td data-testid='suggestionEntry-updated-restaurantCategories'>{updatedRestaurant.categories.map((category) => <span key={category.id}>{category.name}, </span>)}</td>}
+                </tr>
+              </tbody>
+            </Table>
+          </Card.Body>
+        </>
+      }
       <Card.Body className='buttons'>
         <Button
           data-testid='suggestionEntry-approveButton'

--- a/packages/app/src/components/suggestionlist/SuggestionList.js
+++ b/packages/app/src/components/suggestionlist/SuggestionList.js
@@ -152,7 +152,9 @@ SuggestionEntry.propTypes = {
     type: PropTypes.string.isRequired,
     data: PropTypes.shape({
       name: PropTypes.string.isRequired,
-      url: PropTypes.string
+      url: PropTypes.string,
+      id: PropTypes.any,
+      categories: PropTypes.array
     }).isRequired
   }),
   handleApprove: PropTypes.any.isRequired,

--- a/packages/app/src/components/suggestionlist/SuggestionList.test.js
+++ b/packages/app/src/components/suggestionlist/SuggestionList.test.js
@@ -2,69 +2,75 @@ import React from 'react'
 import { fireEvent, waitForElementToBeRemoved } from '@testing-library/react'
 import { SuggestionList, SuggestionEntry } from './SuggestionList'
 import suggestionService from '../../services/suggestion'
+import restaurantService from '../../services/restaurant'
+import categoryService from '../../services/category'
 import { actRender } from '../../test/utilities'
-
 
 jest.mock('../../services/restaurant.js')
 jest.mock('../../services/suggestion.js')
+jest.mock('../../services/category.js')
 
-const testSuggestion = {
-  type: 'ADD',
-  id: 1,
-  data: {
+
+const testRestaurants = [
+  {
     name: 'Luigi\'s pizza',
     url: 'www.pizza.fi',
-    id: 1
+    id: 1,
+    categories: []
+  },
+  {
+    name: 'Pizzeria Rax',
+    url: 'www.rax.fi',
+    id: 2,
+    categories: []
+  },
+  {
+    name: 'Ravintola Artjärvi',
+    url: 'www.bestfood.fi',
+    id: 3,
+    categories: []
+  },
+  {
+    name: 'Kalevankadun Salaattibaari',
+    url: 'www.k-salaatti.fi',
+    id: 4,
+    categories: []
   }
-}
+]
+
+const testSuggestions = [
+  {
+    type: 'ADD',
+    id: 1,
+    data: testRestaurants[0]
+  },
+  {
+    type: 'ADD',
+    id: 2,
+    data: testRestaurants[1]
+  },
+  {
+    type: 'REMOVE',
+    id: 3,
+    data: testRestaurants[2]
+  },
+  {
+    type: 'EDIT',
+    id: 4,
+    data: testRestaurants[3]
+  }
+]
 
 beforeEach(() => {
   jest.clearAllMocks()
-  suggestionService.getAll.mockResolvedValue(
-    [
-      {
-        type: 'ADD',
-        id: 1,
-        data: {
-          name: 'Luigi\'s pizza',
-          url: 'www.pizza.fi',
-          id: 1
-        }
-      },
-      {
-        type: 'ADD',
-        id: 2,
-        data: {
-          name: 'Pizzeria Rax',
-          url: 'www.rax.fi',
-          id: 2
-        }
-      },
-      {
-        type: 'REMOVE',
-        id: 3,
-        data: {
-          name: 'Ravintola Artjärvi',
-          url: 'www.bestfood.fi',
-          id: 3
-        }
-      }
-    ]
-  )
+  suggestionService.getAll.mockResolvedValue(testSuggestions)
+  restaurantService.getOneById.mockResolvedValue(testSuggestions[0])
+  categoryService.getAll.mockResolvedValue(['Salad', 'Burger', 'Hangover'])
 })
 
 test('a suggestion is rendered if one exists', async () => {
-  suggestionService.getAll.mockResolvedValue([
-    {
-      type: 'REMOVE',
-      id: 3,
-      data: {
-        name: 'Ravintola Artjärvi',
-        url: 'www.bestfood.fi',
-        id: 3
-      }
-    }
-  ])
+  suggestionService.getAll.mockResolvedValue([testSuggestions[0]])
+  restaurantService.getOneById.mockResolvedValue(testRestaurants[0])
 
   const { queryByTestId } = await actRender(<SuggestionList />, ['/admin/suggestions'])
 
@@ -72,7 +78,7 @@ test('a suggestion is rendered if one exists', async () => {
   expect(suggestion).toBeInTheDocument()
 })
 
-test('multiple restaurants are rendered if more than one exist', async () => {
+test.only('multiple restaurants are rendered if more than one exist', async () => {
   const { queryAllByTestId } = await actRender(
     <SuggestionList />, ['/admin/suggestions']
   )

--- a/packages/app/src/components/suggestionlist/SuggestionList.test.js
+++ b/packages/app/src/components/suggestionlist/SuggestionList.test.js
@@ -10,31 +10,45 @@ jest.mock('../../services/restaurant.js')
 jest.mock('../../services/suggestion.js')
 jest.mock('../../services/category.js')
 
+const testCategories = [
+  {
+    id: 1,
+    name: 'Salad'
+  },
+  {
+    id: 2,
+    name: 'Burger'
+  },
+  {
+    id: 3,
+    name: 'Hangover'
+  }
+]
 
 const testRestaurants = [
   {
     name: 'Luigi\'s pizza',
     url: 'www.pizza.fi',
     id: 1,
-    categories: []
+    categories: [2]
   },
   {
     name: 'Pizzeria Rax',
     url: 'www.rax.fi',
     id: 2,
-    categories: []
+    categories: [1, 2]
   },
   {
     name: 'Ravintola Artjärvi',
     url: 'www.bestfood.fi',
     id: 3,
-    categories: []
+    categories: [1]
   },
   {
     name: 'Kalevankadun Salaattibaari',
     url: 'www.k-salaatti.fi',
     id: 4,
-    categories: []
+    categories: [1, 2, 3]
   }
 ]
 
@@ -64,8 +78,12 @@ const testSuggestions = [
 beforeEach(() => {
   jest.clearAllMocks()
   suggestionService.getAll.mockResolvedValue(testSuggestions)
-  restaurantService.getOneById.mockResolvedValue(testSuggestions[0])
-  categoryService.getAll.mockResolvedValue(['Salad', 'Burger', 'Hangover'])
+  categoryService.getAll.mockResolvedValue(testCategories)
+
+  restaurantService.getOneById.mockImplementation((id) => {
+    const restaurant = testRestaurants[id - 1]
+    return {...restaurant, categories: testCategories.filter(c => restaurant.categories.includes(c.id))}
+  })
 })
 
 test('a suggestion is rendered if one exists', async () => {
@@ -75,10 +93,11 @@ test('a suggestion is rendered if one exists', async () => {
   const { queryByTestId } = await actRender(<SuggestionList />, ['/admin/suggestions'])
 
   const suggestion = await queryByTestId('suggestionList-entry')
+
   expect(suggestion).toBeInTheDocument()
 })
 
-test.only('multiple restaurants are rendered if more than one exist', async () => {
+test('multiple restaurants are rendered if more than one exist', async () => {
   const { queryAllByTestId } = await actRender(
     <SuggestionList />, ['/admin/suggestions']
   )
@@ -87,11 +106,26 @@ test.only('multiple restaurants are rendered if more than one exist', async () =
   expect(suggestions.length).toBeGreaterThan(1)
 })
 
+test('if no suggestions are listed an alert message is rendered', async () => {
+  suggestionService.getAll.mockResolvedValue([])
+
+  const { queryByTestId } = await actRender(<SuggestionList />, ['/admin/suggestions'])
+
+  const alertMessage = await queryByTestId('suggestionList-alertMessage')
+  expect(alertMessage).toBeInTheDocument()
+})
+
+/**
+ * BELOW: SuggestionEntry specific tests!
+ */
+
 test('pressing the approve button calls the provided callback', async () => {
   const mockOnApprove = jest.fn()
+  const suggestion = testSuggestions[0]
+
   const { queryByTestId } = await actRender(
     <SuggestionEntry
-      suggestion={testSuggestion}
+      suggestion={suggestion}
       handleApprove={mockOnApprove}
       handleReject={jest.fn()} />,
     ['/admin/suggestions']
@@ -99,13 +133,15 @@ test('pressing the approve button calls the provided callback', async () => {
 
   const approveButton = await queryByTestId('suggestionEntry-approveButton')
   fireEvent.click(approveButton)
-  expect(mockOnApprove).toBeCalledWith(testSuggestion.id)
+  expect(mockOnApprove).toBeCalledWith(suggestion.id)
 })
 
 test('renders approve button', async () => {
+  const suggestion = testSuggestions[0]
+
   const { queryByTestId } = await actRender(
     <SuggestionEntry
-      suggestion={testSuggestion}
+      suggestion={suggestion}
       handleApprove={jest.mock()}
       handleReject={jest.mock()} />,
     ['/admin/suggestions']
@@ -117,9 +153,11 @@ test('renders approve button', async () => {
 
 test('pressing the reject button calls the provided callback', async () => {
   const mockOnReject = jest.fn()
+  const suggestion = testSuggestions[0]
+
   const { queryByTestId } = await actRender(
     <SuggestionEntry
-      suggestion={testSuggestion}
+      suggestion={suggestion}
       handleApprove={jest.fn()}
       handleReject={mockOnReject} />,
     ['/admin/suggestions']
@@ -127,13 +165,15 @@ test('pressing the reject button calls the provided callback', async () => {
 
   const rejectButton = await queryByTestId('suggestionEntry-rejectButton')
   fireEvent.click(rejectButton)
-  expect(mockOnReject).toBeCalledWith(testSuggestion.id)
+  expect(mockOnReject).toBeCalledWith(suggestion.id)
 })
 
 test('renders reject button', async () => {
+  const suggestion = testSuggestions[0]
+
   const { queryByTestId } = await actRender(
     <SuggestionEntry
-      suggestion={testSuggestion}
+      suggestion={suggestion}
       handleApprove={jest.mock()}
       handleReject={jest.mock()} />,
     ['/admin/suggestions']
@@ -143,26 +183,101 @@ test('renders reject button', async () => {
   expect(rejectButton).toBeInTheDocument()
 })
 
-test('if no suggestions are listed an alert message is rendered', async () => {
-  suggestionService.getAll.mockResolvedValue([
-    {
-      type: 'REMOVE',
-      id: 3,
-      data: {
-        name: 'Ravintola Artjärvi',
-        url: 'www.bestfood.fi',
-        id: 3
-      }
-    }
-  ])
+describe('The information within SuggestionEntry is rendered', () => {
 
-  const { getByTestId, queryByTestId } = await actRender(<SuggestionList />, ['/admin/suggestions'])
+  test('Suggestion type is rendered', async () => {
+    const suggestion = testSuggestions[2]
 
-  const rejectButton = await queryByTestId('suggestionEntry-rejectButton')
-  fireEvent.click(rejectButton)
+    const { getByTestId } = await actRender(
+      <SuggestionEntry
+        suggestion={suggestion}
+        handleApprove={jest.mock()}
+        handleReject={jest.mock()} />,
+      ['/admin/suggestions']
+    )
 
-  await waitForElementToBeRemoved(() => getByTestId('suggestionList-entry'))
+    const typeElement = await getByTestId('suggestionEntry-type')
+    expect(typeElement).toBeInTheDocument()
+  })
 
-  const alertMessage = await queryByTestId('suggestionList-alertMessage')
-  expect(alertMessage).toBeInTheDocument()
+  test('Name of the restaurant related to the suggestion is rendered', async () => {
+    const suggestion = testSuggestions[2]
+
+    const { getByTestId } = await actRender(
+      <SuggestionEntry
+        suggestion={suggestion}
+        handleApprove={jest.mock()}
+        handleReject={jest.mock()} />,
+      ['/admin/suggestions']
+    )
+
+    const nameElement = await getByTestId('suggestionEntry-restaurantName')
+    expect(nameElement).toBeInTheDocument()
+  })
+
+  test('Updated fields are not rendered for ADD type suggestions', async () => {
+    const suggestion = testSuggestions[0]
+
+    const { queryByTestId } = await actRender(
+      <SuggestionEntry
+        suggestion={suggestion}
+        handleApprove={jest.mock()}
+        handleReject={jest.mock()} />,
+      ['/admin/suggestions']
+    )
+
+    const tableHeader = await queryByTestId('suggestionEntry-updated-th')
+    const restaurantName = await queryByTestId('suggestionEntry-updated-restaurantName')
+    const restaurantUrl = await queryByTestId('suggestionEntry-updated-restaurantUrl')
+    const restaurantCategories = await queryByTestId('suggestionEntry-updated-restaurantCategories')
+
+    expect(tableHeader).not.toBeInTheDocument()
+    expect(restaurantName).not.toBeInTheDocument()
+    expect(restaurantUrl).not.toBeInTheDocument()
+    expect(restaurantCategories).not.toBeInTheDocument()
+  })
+
+  test('Updated fields are not rendered for REMOVE type suggestions', async () => {
+    const suggestion = testSuggestions[2]
+
+    const { queryByTestId } = await actRender(
+      <SuggestionEntry
+        suggestion={suggestion}
+        handleApprove={jest.mock()}
+        handleReject={jest.mock()} />,
+      ['/admin/suggestions']
+    )
+
+    const tableHeader = await queryByTestId('suggestionEntry-updated-th')
+    const restaurantName = await queryByTestId('suggestionEntry-updated-restaurantName')
+    const restaurantUrl = await queryByTestId('suggestionEntry-updated-restaurantUrl')
+    const restaurantCategories = await queryByTestId('suggestionEntry-updated-restaurantCategories')
+
+    expect(tableHeader).not.toBeInTheDocument()
+    expect(restaurantName).not.toBeInTheDocument()
+    expect(restaurantUrl).not.toBeInTheDocument()
+    expect(restaurantCategories).not.toBeInTheDocument()
+  })
+
+  test('Updated fields are rendered for EDIT type suggestions', async () => {
+    const suggestion = testSuggestions[3]
+
+    const { getByTestId } = await actRender(
+      <SuggestionEntry
+        suggestion={suggestion}
+        handleApprove={jest.mock()}
+        handleReject={jest.mock()} />,
+      ['/admin/suggestions']
+    )
+
+    const tableHeader = await getByTestId('suggestionEntry-updated-th')
+    const restaurantName = await getByTestId('suggestionEntry-updated-restaurantName')
+    const restaurantUrl = await getByTestId('suggestionEntry-updated-restaurantUrl')
+    const restaurantCategories = await getByTestId('suggestionEntry-updated-restaurantCategories')
+
+    expect(tableHeader).toBeInTheDocument()
+    expect(restaurantName).toBeInTheDocument()
+    expect(restaurantUrl).toBeInTheDocument()
+    expect(restaurantCategories).toBeInTheDocument()
+  })
 })

--- a/packages/app/src/components/suggestionlist/SuggestionList.test.js
+++ b/packages/app/src/components/suggestionlist/SuggestionList.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { fireEvent, waitForElementToBeRemoved } from '@testing-library/react'
+import { fireEvent } from '@testing-library/react'
 import { SuggestionList, SuggestionEntry } from './SuggestionList'
 import suggestionService from '../../services/suggestion'
 import restaurantService from '../../services/restaurant'

--- a/packages/app/src/services/suggestion.js
+++ b/packages/app/src/services/suggestion.js
@@ -27,10 +27,16 @@ const removeRestaurant = async (restaurant) => {
   return response.data
 }
 
+const editRestaurant = async (restaurant) => {
+  const response = await axios.post(`${baseUrl}/edit`, restaurant)
+  return response.data
+}
+
 export default {
   getAll,
   approve,
   reject,
   addRestaurant,
-  removeRestaurant
+  removeRestaurant,
+  editRestaurant
 }

--- a/packages/backend/src/controllers/restaurants.js
+++ b/packages/backend/src/controllers/restaurants.js
@@ -48,7 +48,6 @@ const removeRestaurantFromCategories = async (restaurantId, categoryIds) => {
 const tryRemoveSuggestionsByRestaurant = async (restaurantId) => {
   const removedSuggestions = await Suggestion.deleteMany({ 'data._id': { $eq: restaurantId } })
 
-
   return removedSuggestions
 }
 
@@ -180,5 +179,6 @@ restaurantsRouter.delete('/:id', async (request, response, next) => {
 module.exports = {
   restaurantsRouter,
   tryRemoveRestaurant,
-  tryCreateRestaurant
+  tryCreateRestaurant,
+  tryUpdateRestaurant
 }

--- a/packages/backend/src/models/suggestion.js
+++ b/packages/backend/src/models/suggestion.js
@@ -7,7 +7,7 @@ const suggestionSchema = new mongoose.Schema({
   type: {
     type: String,
     required: true,
-    enum: ['ADD', 'REMOVE'],
+    enum: ['ADD', 'REMOVE', 'EDIT'],
   },
   data: {
     type: restaurantSchema,

--- a/packages/backend/src/requests/suggestions_edit.rest
+++ b/packages/backend/src/requests/suggestions_edit.rest
@@ -1,0 +1,9 @@
+POST http://localhost:3001/api/suggestions/edit HTTP/1.1
+Content-Type: application/json
+
+{
+        "id": "5e4bc29bf481f53cebbd785d",
+        "name": "Kalevankadun Salaatti",
+        "url": "https://www.kaleva-salaatti.fi",
+        "categories": []
+}


### PR DESCRIPTION
**Backend:**
- New API endpoint: `suggestions/edit` - Creates a new suggestion to edit the details of a restaurant
- Updated endpoint `suggestions/approve` - Now also handles approvals of suggestions of 'EDIT' type

**Frontend:**
- The edit button for restaurants is also shown to unauthenticated users
- Edits submitted by unauthenticated users are sent to the admin dashboard
- The admin dashboards now shows more information regarding suggestions:
  - The name, url and categories of the concerned restaurant
  - If the suggestion is requesting edits, both the old details and the suggested details are shown side-by-side