### PR TITLE
Added backend service and controller for Google APIs

### DIFF
--- a/documentation/api/places.md
+++ b/documentation/api/places.md
@@ -1,0 +1,59 @@
+Endpoints: `/api/places`
+=============================
+
+Provides access to autocompletion and restaurant details resources. All place IDs are Google Places API place IDs.
+
+
+`GET /api/places/autocomplete/:text`
+-----------------------
+*"autocomplete"* -endpoint, provides a list autocompletion suggestions based on given input string.
+
+### Response
+
+| Header         | value              |
+| -------------- | ------------------ |
+| `Content-Type` | `application/json` |
+| `Status Code`  | `200 OK`           |
+
+Response body contains an arrray of object with shape
+```js
+[
+  {
+    "name": string,
+    "address": string,
+    "distance": number,
+    "placeId": string
+  },
+  // ...
+]
+```
+
+### Errors
+ - `Status: 404 Not Found` - if no places were found with the search string
+ - `Status: 503 Service Unavailable` - if the underlying Google API key has exhausted monthly quota
+
+
+`GET /api/places/details/:place_id`
+--------------------------
+*"Details"* -endpoint; Given a valid Google Place ID, returns details of the corresponding place.
+
+### Response
+| Header         | value              |
+| -------------- | ------------------ |
+| `Content-Type` | `application/json` |
+| `Status Code`  | `200 OK`           |
+
+Response body contains details of the requested place, as per [Google API documentation](https://developers.google.com/places/web-service/details#fields)
+
+```js
+{
+  "attributions": [ /* HTML attributions */ ],
+  "result": {
+    // refer to Google Places API documentation
+  }
+}
+```
+
+### Errors
+ - `Status: 404 Not Found` - if malformed or unknown ID is provided. Response body contains the error message.
+ - `Status: 503 Service Unavailable` - if the underlying Google API key has exhausted monthly quota

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -10,6 +10,7 @@
     "add-user": "node ./scripts/add_user.js"
   },
   "dependencies": {
+    "axios": "^0.19.2",
     "bcrypt": "^3.0.8",
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",

--- a/packages/backend/src/app.js
+++ b/packages/backend/src/app.js
@@ -7,6 +7,7 @@ const { restaurantsRouter } = require('./controllers/restaurants')
 const categoriesRouter = require('./controllers/categories')
 const authRouter = require('./controllers/auth')
 const suggestionRouter = require('./controllers/suggestions')
+const placesRouter = require('./controllers/places')
 
 const config = require('./config')
 
@@ -26,6 +27,7 @@ app.use('/api/restaurants', restaurantsRouter)
 app.use('/api/categories', categoriesRouter)
 app.use('/api/auth', authRouter)
 app.use('/api/suggestions', suggestionRouter)
+app.use('/api/places', placesRouter)
 
 app.get('/*', (req, res) => {
   res.sendFile(path.join(config.staticDir, 'index.html'))
@@ -40,7 +42,10 @@ app.use((error, request, response, next) => {
     return response.status(400).send({ error: error.message })
   } else if (error.name === 'PasswordExpired') {
     return response.status(403).send({ error: error.message })
+  } else if (error.name === 'QueryLimit') {
+    return response.status(503).send({ error: error.message })
   }
+
   next(error)
 })
 

--- a/packages/backend/src/config.js
+++ b/packages/backend/src/config.js
@@ -23,6 +23,9 @@ const bcryptSaltRounds = process.env.NODE_ENV === 'test'
   ? 4
   : process.env.SALT_ROUNDS || 10
 
+const originLatitude = 60.170000
+const originLongitude = 24.941944
+
 if (dbUrl === null || dbUrl === undefined) {
   throw new Error('Database URL is not defined! Environment variable MONGODB_URI was empty. Either define it manually or add it to your .env')
 }
@@ -42,5 +45,7 @@ module.exports = {
   dbName,
   jwtSecret,
   bcryptSaltRounds,
-  googleApiKey
+  googleApiKey,
+  originLatitude,
+  originLongitude
 }

--- a/packages/backend/src/config.js
+++ b/packages/backend/src/config.js
@@ -15,6 +15,10 @@ const jwtSecret = process.env.NODE_ENV === 'test'
   ? 'sekret'
   : process.env.SECRET
 
+const googleApiKey = process.env.NODE_ENV === 'test'
+  ? 'gapikey'
+  : process.env.GOOGLE_API_KEY
+
 const bcryptSaltRounds = process.env.NODE_ENV === 'test'
   ? 4
   : process.env.SALT_ROUNDS || 10
@@ -27,6 +31,10 @@ if (jwtSecret === null || jwtSecret === undefined) {
   throw new Error('JWT Secret is not defined! Environment variable SECRET was empty. Either define it manually or add it to your .env')
 }
 
+if (googleApiKey === null || googleApiKey === undefined) {
+  throw new Error('Google API Key is not defined! Environment variable GOOGLE_API_KEY was empty. Either define it manually or add it to your .env')
+}
+
 module.exports = {
   port,
   staticDir,
@@ -34,4 +42,5 @@ module.exports = {
   dbName,
   jwtSecret,
   bcryptSaltRounds,
+  googleApiKey
 }

--- a/packages/backend/src/controllers/places.js
+++ b/packages/backend/src/controllers/places.js
@@ -1,0 +1,71 @@
+const placesRouter = require('express').Router()
+
+const google = require('../services/google')
+
+
+/**
+ * Tries to guess address based on a prediction. The description field usually should contain
+ * enough information for getting a close-enough looking address.
+ * 
+ * @param {*} prediction the prediction to make the guess for
+ */
+const tryGuessAddress = (prediction) => {
+  return prediction.description
+}
+
+
+/**
+ * Tries to guess address based on a prediction. Uses the structured_formatting property as
+ * for establishments its main_text sub-property should usually be the name of the place.
+ * 
+ * If prediction has no structured_formatting, returns the description (which likely
+ * contains the address and thus is quite sub-optimal).
+ * 
+ * @param {*} prediction the prediction to make the guess for
+ */
+const tryGuessName = (prediction) => {
+  const maybeStructuredFormatting = prediction.structured_formatting
+  return maybeStructuredFormatting === undefined
+    ? prediction.description
+    : maybeStructuredFormatting.main_text
+}
+
+
+placesRouter.get('/details/:place_id', async (request, response, next) => {
+  try {
+    const placeId = request.params.place_id
+    const details = await google.findDetails(placeId)
+    if (details === null) {
+      return response.status(404).send({ error: 'No places found with the given place id' })
+    }
+
+    return response.status(200).send(details)
+  } catch (error) {
+    next(error)
+  }
+})
+
+placesRouter.get('/autocomplete/:name', async (request, response, next) => {
+  try {
+    const text = request.params.name
+
+    const predictions = await google.autocomplete(text)
+    if (predictions === null) {
+      return response.status(404).send({ error: 'No places found with given name' })
+    }
+
+    const result = predictions
+      .map(prediction => ({
+        name: tryGuessName(prediction),
+        address: tryGuessAddress(prediction),
+        distance: prediction.distance_meters,
+        placeId: prediction.place_id
+      }))
+
+    return response.status(200).send(result)
+  } catch (error) {
+    next(error)
+  }
+})
+
+module.exports = placesRouter

--- a/packages/backend/src/controllers/places.js
+++ b/packages/backend/src/controllers/places.js
@@ -50,9 +50,6 @@ placesRouter.get('/autocomplete/:name', async (request, response, next) => {
     const text = request.params.name
 
     const predictions = await google.autocomplete(text)
-    if (predictions === null) {
-      return response.status(404).send({ error: 'No places found with given name' })
-    }
 
     const result = predictions
       .map(prediction => ({

--- a/packages/backend/src/controllers/places.test.js
+++ b/packages/backend/src/controllers/places.test.js
@@ -226,6 +226,14 @@ test('successful details query returns with status 200', async () => {
     .expect(200)
 })
 
+test('failed details query returns with status 404', async () => {
+  google.findDetails.mockResolvedValue(null)
+
+  await server
+    .get(`/api/places/details/${detailsQuery}`)
+    .expect(404)
+})
+
 test('over query limit details query returns with status 503', async () => {
   const mockReject = new google.QueryLimitError('Monthly quota exceeded!')
   mockReject.name = 'QueryLimit'

--- a/packages/backend/src/controllers/places.test.js
+++ b/packages/backend/src/controllers/places.test.js
@@ -1,0 +1,256 @@
+const supertest = require('supertest')
+const app = require('../app')
+const google = require('../services/google')
+
+const dbUtil = require('../test/dbUtil')
+
+jest.mock('../services/google')
+
+const autocompleteQuery = 'fuku'
+const autocompleteResponse = [
+  {
+    description: 'Fuku sushi, Mannerheimintie, Helsinki, Finland',
+    distance_meters: 189,
+    id: '78e9b5d0e37f12785f21a87cc1a0c60cd33d4e3a',
+    matched_substrings: [{ length: 4, offset: 0 }],
+    place_id: 'ChIJLxuNHssLkkYRE4g89GmS8_0',
+    reference: 'ChIJLxuNHssLkkYRE4g89GmS8_0',
+    structured_formatting: {
+      main_text: 'Fuku sushi',
+      main_text_matched_substrings: [{ length: 4, offset: 0 }],
+      secondary_text: 'Mannerheimintie, Helsinki, Finland'
+    },
+    terms: [
+      { offset: 0, value: 'Fuku sushi' },
+      { offset: 12, value: 'Mannerheimintie' },
+      { offset: 29, value: 'Helsinki' },
+      { offset: 39, value: 'Finland' }
+    ],
+    types: ['restaurant', 'food', 'point_of_interest', 'establishment']
+  },
+  {
+    description: 'Fuku Supreme, Leppävaarankatu, Espoo, Finland',
+    distance_meters: 9055,
+    id: '937f4f00caa140a670c32de544a30614d219ee6f',
+    matched_substrings: [{ length: 4, offset: 0 }],
+    place_id: 'ChIJxZrtjHj2jUYRUnc7prDjZaI',
+    reference: 'ChIJxZrtjHj2jUYRUnc7prDjZaI',
+    structured_formatting: {
+      main_text: 'Fuku Supreme',
+      main_text_matched_substrings: [{ length: 4, offset: 0 }],
+      secondary_text: 'Leppävaarankatu, Espoo, Finland'
+    },
+    terms: [
+      { offset: 0, value: 'Fuku Supreme' },
+      { offset: 14, value: 'Leppävaarankatu' },
+      { offset: 31, value: 'Espoo' },
+      { offset: 38, value: 'Finland' }
+    ],
+    types: ['restaurant', 'food', 'point_of_interest', 'establishment']
+  }
+]
+
+const detailsQuery = 'ChIJLxuNHssLkkYRE4g89GmS8_0'
+const detailsResponse = {
+  'attributions': [],
+  'result': {
+    'formatted_address': 'Mannerheimintie 18, 00100 Helsinki, Finland',
+    'geometry': {
+      'location': {
+        'lat': 60.16920340000001,
+        'lng': 24.9389156
+      },
+      'viewport': {
+        'northeast': {
+          'lat': 60.1705970302915,
+          'lng': 24.9403847302915
+        },
+        'southwest': {
+          'lat': 60.1678990697085,
+          'lng': 24.9376867697085
+        }
+      }
+    },
+    'name': 'Fuku Helsinki',
+    'opening_hours': {
+      'open_now': false,
+      'periods': [
+        {
+          'close': {
+            'day': 0,
+            'time': '2200'
+          },
+          'open': {
+            'day': 0,
+            'time': '1100'
+          }
+        },
+        {
+          'close': {
+            'day': 1,
+            'time': '2200'
+          },
+          'open': {
+            'day': 1,
+            'time': '1100'
+          }
+        },
+        {
+          'close': {
+            'day': 2,
+            'time': '2200'
+          },
+          'open': {
+            'day': 2,
+            'time': '1100'
+          }
+        },
+        {
+          'close': {
+            'day': 3,
+            'time': '2200'
+          },
+          'open': {
+            'day': 3,
+            'time': '1100'
+          }
+        },
+        {
+          'close': {
+            'day': 4,
+            'time': '2200'
+          },
+          'open': {
+            'day': 4,
+            'time': '1100'
+          }
+        },
+        {
+          'close': {
+            'day': 5,
+            'time': '2300'
+          },
+          'open': {
+            'day': 5,
+            'time': '1100'
+          }
+        },
+        {
+          'close': {
+            'day': 6,
+            'time': '2300'
+          },
+          'open': {
+            'day': 6,
+            'time': '1100'
+          }
+        }
+      ],
+      'weekday_text': [
+        'Monday: 11:00 AM – 10:00 PM', 'Tuesday: 11:00 AM – 10:00 PM', 'Wednesday: 11:00 AM – 10:00 PM', 'Thursday: 11:00 AM – 10:00 PM', 'Friday: 11:00 AM – 11:00 PM', 'Saturday: 11:00 AM – 11:00 PM', 'Sunday: 11:00 AM – 10:00 PM'
+      ]
+    },
+    'photos': [
+      {
+        'height': 2250,
+        'html_attributions': [
+          '<a href=\'https://maps.google.com/maps/contrib/102470036477190220549\'>Claudio Bucci</a>'
+        ],
+        'photo_reference': 'CmRaAAAA46-yJLhFgdjYK-AogTLTxL2uFVwhkEr1Ef7fBui951h5z_aD8VFUM57U06KTmFkLJ_TfbTFBdD7os0hgv9KOjDK8wa6firFtDF3Doq3XrVjT_nR2eOMDyOs2785GLEkrEhCymhutRWisiZnGgI9CxEFnGhRhLYjlA6HzIwzyYF5ndcJgvzVtew',
+        'width': 4000
+      },
+      {
+        'height': 2976,
+        'html_attributions': [
+          '<a href=\'https://maps.google.com/maps/contrib/118050262657914020677\'>程慧慧</a>'
+        ],
+        'photo_reference': 'CmRaAAAAZACyaR_gEm3lLJ0Zp5PxiArJLp6qA0zQ70bXqtJZMJvoTe_zaPL804N27jr6x7NIiivgyfhwb2h4oGw230k3z0UfELJdzGaVWkQRHTr9P9uP3g4PxZFTtbV5YE3_kM5xEhB12ZchhhXYxqj2Do14oCkIGhRjnNWWKkRS3jBhhwsWl0MNSbp1nA',
+        'width': 3968
+      },
+    ],
+    'place_id': 'ChIJLxuNHssLkkYRE4g89GmS8_0'
+  }
+}
+
+let server
+beforeEach(() => {
+  jest.clearAllMocks()
+  server = supertest(app)
+})
+
+test('successful autocomplete returns with status 200', async () => {
+  google.autocomplete.mockResolvedValue(autocompleteResponse)
+
+  await server
+    .get(`/api/places/autocomplete/${autocompleteQuery}`)
+    .expect(200)
+})
+
+test('over query limit autocomplete returns with status 503', async () => {
+  const mockReject = new google.QueryLimitError('Monthly quota exceeded!')
+  mockReject.name = 'QueryLimit'
+  google.autocomplete.mockRejectedValue(mockReject)
+
+  await server
+    .get(`/api/places/autocomplete/${autocompleteQuery}`)
+    .expect(503)
+})
+
+test('autocomplete parses the information correctly', async () => {
+  google.autocomplete.mockResolvedValue(autocompleteResponse)
+
+  const { body: contents } = await server
+    .get(`/api/places/autocomplete/${autocompleteQuery}`)
+
+  expect(contents).toMatchObject([
+    {
+      name: expect.stringMatching(/fuku sushi/i),
+      address: expect.stringMatching(/Mannerheimintie/i),
+      placeId: 'ChIJLxuNHssLkkYRE4g89GmS8_0',
+      distance: 189,
+    },
+    {
+      name: expect.stringMatching(/fuku supreme/i),
+      address: expect.stringMatching(/Leppävaarankatu/i),
+      placeId: 'ChIJxZrtjHj2jUYRUnc7prDjZaI',
+      distance: 9055,
+    }
+  ])
+})
+
+test('successful details query returns with status 200', async () => {
+  google.findDetails.mockResolvedValue(detailsResponse)
+
+  await server
+    .get(`/api/places/details/${detailsQuery}`)
+    .expect(200)
+})
+
+test('over query limit details query returns with status 503', async () => {
+  const mockReject = new google.QueryLimitError('Monthly quota exceeded!')
+  mockReject.name = 'QueryLimit'
+  google.findDetails.mockRejectedValue(mockReject)
+
+  await server
+    .get(`/api/places/details/${detailsQuery}`)
+    .expect(503)
+})
+
+test('find details returns some relevant information', async () => {
+  google.findDetails.mockResolvedValue(detailsResponse)
+
+  const { body: contents } = await server
+    .get(`/api/places/details/${detailsQuery}`)
+
+  expect(contents.attributions).toHaveLength(0)
+  expect(contents.result).toMatchObject({
+    formatted_address: expect.stringMatching(/.*Mannerheimintie 18.*Helsinki.*/i),
+    place_id: 'ChIJLxuNHssLkkYRE4g89GmS8_0',
+    geometry: expect.objectContaining({
+      location: {
+        lat: 60.16920340000001,
+        lng: 24.9389156
+      }
+    }),
+  })
+})

--- a/packages/backend/src/models/restaurant.js
+++ b/packages/backend/src/models/restaurant.js
@@ -42,7 +42,7 @@ const restaurantSchema = new mongoose.Schema({
       ref: 'Category'
     }
   ],
-  placeid: {
+  placeId: {
     type: String,
     required: features.googleApi,
   },

--- a/packages/backend/src/models/restaurant.js
+++ b/packages/backend/src/models/restaurant.js
@@ -1,3 +1,5 @@
+const features = require('../../../util/features')
+
 const mongoose = require('mongoose')
 mongoose.set('useFindAndModify', false)
 
@@ -39,7 +41,11 @@ const restaurantSchema = new mongoose.Schema({
       type: mongoose.Schema.Types.ObjectId,
       ref: 'Category'
     }
-  ]
+  ],
+  placeid: {
+    type: String,
+    required: features.googleApi,
+  },
 })
 
 restaurantSchema.set('toJSON', {

--- a/packages/backend/src/requests/autocomplete.rest
+++ b/packages/backend/src/requests/autocomplete.rest
@@ -1,0 +1,1 @@
+GET http://localhost:3001/api/places/autocomplete/fuku HTTP/1.1

--- a/packages/backend/src/requests/place_details.rest
+++ b/packages/backend/src/requests/place_details.rest
@@ -1,0 +1,1 @@
+GET http://localhost:3001/api/places/details/ChIJLxuNHssLkkYRE4g89GmS8_0 HTTP/1.1

--- a/packages/backend/src/services/google.js
+++ b/packages/backend/src/services/google.js
@@ -4,9 +4,21 @@ const config = require('../config')
 const baseUrl = 'https://maps.googleapis.com/maps/api'
 
 const API_KEY = config.googleApiKey
+const SEARCH_RADIUS = 10000 // in meters
+const LATITUDE = config.originLatitude
+const LONGITUDE = config.originLongitude
 
 const FIELDS = 'formatted_address,name,photos,opening_hours,permanently_closed,place_id,geometry'
 
+/**
+ * Thrown to indicate that the API key has exhausted its monthly quota.
+ */
+class QueryLimitError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'QueryLimit'
+  }
+}
 
 /**
  * Makes a request to the Google Find Place API to fetch a place based on given keyword.
@@ -18,9 +30,82 @@ const findPlaceByKeyword = async (keyword) => {
   const outputFormat = 'json'   // 'json' | 'xml'
   const inputType = 'textquery' // 'textquery' | 'phonenumber'
   const response = await axios.get(`${baseUrl}/place/findplacefromtext/${outputFormat}?key=${API_KEY}&input=${keyword}&inputtype=${inputType}&fields=${FIELDS}`)
-  return response.data.candidates
+  switch (response.data.status) {
+    case 'OK':
+      return response.data.candidates
+    case 'ZERO_RESULTS':
+      return []
+    case 'OVER_QUERY_LIMIT':
+      throw new QueryLimitError('Monthly quota exceeded!')
+    default:
+      throw new Error('Finding place failed')
+  }
 }
 
+/**
+ * Finds additional details for a place ID. Use autocomplete or find place queries to fetch a place ID, and
+ * once sure that the ID is for the correct place, you can start querying for details.
+ * 
+ * Result is unparsed response from the Google Place Details API. Refer to https://developers.google.com/places/web-service/details#fields
+ * for details on response fields.
+ * 
+ * If the result contains an array of HTML attributions, they must be shown to the user due to legal reasons.
+ * 
+ * @param {string} placeId The Google Place ID to search for
+ * 
+ * @returns null if place was not found, the object containing the details otherwise
+ */
+const findDetails = async (placeId) => {
+  const outputFormat = 'json'   // 'json' | 'xml'
+  const response = await axios.get(`${baseUrl}/place/details/${outputFormat}?key=${API_KEY}&place_id=${placeId}&fields=${FIELDS}`)
+  switch (response.data.status) {
+    case 'ZERO_RESULTS':          // Place ID was valid but removed/hidden
+    case 'NOT_FOUND':             // Place ID does not exist
+      return null
+    case 'OK':                    // Place found and OK
+      return {
+        attributions: response.data.html_attributions,
+        result: response.data.result
+      }
+    case 'OVER_QUERY_LIMIT':      // Quota exceeded
+      throw new QueryLimitError('Monthly quota exceeded!')
+    default:                      // Something unexpected
+      throw new Error('Finding place details failed')
+  }
+}
+
+/**
+ * Makes a request to the Google Place Autocomplete API to fetch a place prediction based on currently typed string.
+ * Returns an array of prediction objects with format as per Google API documentation.
+ * 
+ * The "strictbounds" option is set to constrain the results to be inside the defined radius (without
+ * the option the radius is mere "suggestion" and e.g. returns results from Japan when searching for sushi places).
+ * 
+ * Why are the coordinates duplicated, passed in both the "origin" and the "location" options? The former is used
+ * for calculating the straight-line distance to the predicted place, while the latter is used for filtering the
+ * results.
+ * 
+ * @param {string} text currently typed search string
+ */
+const autocomplete = async (text) => {
+  const outputFormat = 'json'   // 'json' | 'xml'
+  const response = await axios.get(`${baseUrl}/place/autocomplete/${outputFormat}?input=${text}&types=establishment&strictbounds&origin=${LATITUDE},${LONGITUDE}&location=${LATITUDE},${LONGITUDE}&radius=${SEARCH_RADIUS}&key=${API_KEY}`)
+  switch (response.data.status) {
+    case 'OK':
+      return response.data.predictions
+    case 'ZERO_RESULTS':
+      return []
+    case 'OVER_QUERY_LIMIT':
+      throw new QueryLimitError('Monthly quota exceeded!')
+    default:
+      throw new Error('Autocomplete failed')
+  }
+}
+
+
 module.exports = {
-  findPlaceByKeyword
+  findPlaceByKeyword,
+  autocomplete,
+  findDetails,
+  QueryLimitError,
 }

--- a/packages/backend/src/services/google.js
+++ b/packages/backend/src/services/google.js
@@ -1,0 +1,26 @@
+const axios = require('axios').default
+const config = require('../config')
+
+const baseUrl = 'https://maps.googleapis.com/maps/api'
+
+const API_KEY = config.googleApiKey
+
+const FIELDS = 'formatted_address,name,photos,opening_hours,permanently_closed,place_id,geometry'
+
+
+/**
+ * Makes a request to the Google Find Place API to fetch a place based on given keyword.
+ * The keyword can be e.g. the place name or part of address etc.
+ * 
+ * @param {string} keyword search keyword for the API request, matched against address, name and possibly other information
+ */
+const findPlaceByKeyword = async (keyword) => {
+  const outputFormat = 'json'   // 'json' | 'xml'
+  const inputType = 'textquery' // 'textquery' | 'phonenumber'
+  const response = await axios.get(`${baseUrl}/place/findplacefromtext/${outputFormat}?key=${API_KEY}&input=${keyword}&inputtype=${inputType}&fields=${FIELDS}`)
+  return response.data.candidates
+}
+
+module.exports = {
+  findPlaceByKeyword
+}

--- a/packages/util/features.js
+++ b/packages/util/features.js
@@ -8,4 +8,5 @@ const describeIf = (condition, description, fn) => {
 
 module.exports = {
   describeIf,
+  googleApi: false,
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2296,7 +2296,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.1.tgz#7e33d8f7d449b3f673cd72deb9abdc552dbe528e"
   integrity sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
 
-axios@^0.19.1:
+axios@^0.19.1, axios@^0.19.2:
   version "0.19.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
   integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==


### PR DESCRIPTION
Changes:
- New feature toggle for Google API related features. Currently used only for toggling `required` status for the `placeId` property on `Restaurant` model. It should be preferred to gate any related breaking changes behind this toggle to allow merging partially WIP branches to the master.
- New backend *service*: `google`. Allows making place details and autocomplete requests to Google Places API.
- New backend controller/endpoint: `places`. Exposes relevant subset of autocompletion and details queries' features.

This implementation requires `axios` as new backend dependency.

**Note that new backend configuration environment variable is now required.** In order for the backed to start after the changes in this PR, `GOOGLE_API_KEY` environment variable must be defined to a valid up-to-date Google API Key with *Places API* enabled.

Only the backend support was added. No frontend changes are included in this PR.