### PR TITLE
RestaurantForm's google api integration

### DIFF
--- a/documentation/api/places.md
+++ b/documentation/api/places.md
@@ -62,7 +62,6 @@ Response body contains details of the requested place, as per [Google API docume
 `GET /api/places/details/reviews/:place_id`
 --------------------------
 *"reviews"* -endpoint; Given a valid Google Place ID, returns a rating and reviews of the corresponding place.
-
 ### Response
 | Header         | value              |
 | -------------- | ------------------ |
@@ -108,3 +107,29 @@ Response body contains information about the photos of the requested place. The 
 
  - `Status: 404 Not Found` - if malformed or unknown ID is provided. Response body contains the error message.
  - `Status: 503 Service Unavailable` - if the underlying Google API key has exhausted monthly quota
+
+ `GET /api/places/details/addform/:place_id`
+--------------------------
+*"Details"* -endpoint; Given a valid Google Place ID, returns the following details of the corresponding place. 'formatted_address,name,place_id,geometry,website'
+
+### Response
+| Header         | value              |
+| -------------- | ------------------ |
+| `Content-Type` | `application/json` |
+| `Status Code`  | `200 OK`           |
+
+Response body contains details of the requested place, as per [Google API documentation](https://developers.google.com/places/web-service/details#fields)
+
+```js
+{
+  "attributions": [ /* HTML attributions */ ],
+  "result": {
+    // refer to Google Places API documentation
+  }
+}
+```
+
+### Errors
+ - `Status: 404 Not Found` - if malformed or unknown ID is provided. Response body contains the error message.
+ - `Status: 503 Service Unavailable` - if the underlying Google API key has exhausted monthly quota
+

--- a/packages/app/src/components/RestaurantEntry/RestaurantEntry.js
+++ b/packages/app/src/components/RestaurantEntry/RestaurantEntry.js
@@ -34,7 +34,7 @@ const RestaurantEntry = ({ restaurant, showMap }) => {
             <span>Website </span>
             <Link />
           </a>
-        </p>
+        </p> 
       }
       {
         showMap && <RouteMap restaurant={restaurant} />

--- a/packages/app/src/components/Restaurants/AddForm.js
+++ b/packages/app/src/components/Restaurants/AddForm.js
@@ -11,8 +11,7 @@ const AddForm = () => {
     url: '',
     categories: [],
     address: '',
-    distance: 1000,
-    showMap: false
+    distance: 1000
   })
 
   const token = authService.getToken()

--- a/packages/app/src/components/Restaurants/AddForm.test.js
+++ b/packages/app/src/components/Restaurants/AddForm.test.js
@@ -4,12 +4,18 @@ import AddForm from './AddForm'
 
 import categoryService from '../../services/category'
 import locationService from '../../services/location'
+import placeService from '../../services/places'
+
+import testdata from '../../util/testData'
 
 import { actRender } from '../../test/utilities'
 import { act } from 'react-dom/test-utils'
 
 jest.mock('../../services/category.js')
 jest.mock('../../services/location.js')
+jest.mock('../../services/places.js')
+
+
 
 beforeEach(() => {
   jest.clearAllMocks()
@@ -23,6 +29,8 @@ beforeEach(() => {
     from: { lat: 60.17, lon: 24.941944 },
     to: { lat: 60.182315, lon: 24.922893 }
   })
+  placeService.getSuggestions.mockResolvedValue(testdata.getSuggestions())
+  placeService.getRestaurant.mockResolvedValue(testdata.getRestaurant())
 })
 
 test('map is not shown by default in the add form', async () => {

--- a/packages/app/src/components/Restaurants/AutocompleteEntry/AutocompleteEntry.css
+++ b/packages/app/src/components/Restaurants/AutocompleteEntry/AutocompleteEntry.css
@@ -1,0 +1,9 @@
+.list-group-item {
+    color:black;
+    padding: 0.5em 1em;
+}
+
+.list-group-item:hover {
+    transform: scale(1.025);
+    cursor: pointer;
+}

--- a/packages/app/src/components/Restaurants/AutocompleteEntry/AutocompleteEntry.js
+++ b/packages/app/src/components/Restaurants/AutocompleteEntry/AutocompleteEntry.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import { ListGroup, ListGroupItem } from 'react-bootstrap'
+
+import PropTypes from 'prop-types'
+
+import './AutocompleteEntry.css'
+
+const AutocompleteEntry = ({ suggestion, handleClick }) => {
+  return (
+    <ListGroup data-testid='autocomplete-entry' className="list-group-flush">
+      <ListGroupItem onClick={() => handleClick(suggestion)}> {suggestion.address} </ListGroupItem>
+    </ListGroup>
+  )
+}
+
+AutocompleteEntry.propTypes = {
+  suggestion: PropTypes.shape({
+    placeId: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    address: PropTypes.string.isRequired
+  }),
+  handleClick: PropTypes.func.isRequired
+}
+
+export default AutocompleteEntry

--- a/packages/app/src/components/Restaurants/AutocompleteEntry/AutocompleteEntry.js
+++ b/packages/app/src/components/Restaurants/AutocompleteEntry/AutocompleteEntry.js
@@ -7,8 +7,10 @@ import './AutocompleteEntry.css'
 
 const AutocompleteEntry = ({ suggestion, handleClick }) => {
   return (
-    <ListGroup data-testid='autocomplete-entry' className="list-group-flush">
-      <ListGroupItem onClick={() => handleClick(suggestion)}> {suggestion.address} </ListGroupItem>
+    <ListGroup className="list-group-flush">
+      <ListGroupItem data-testid='autocomplete-entry' onClick={() => handleClick(suggestion)}>
+        {suggestion.address}
+      </ListGroupItem>
     </ListGroup>
   )
 }

--- a/packages/app/src/components/Restaurants/AutocompleteList/AutocompleteList.css
+++ b/packages/app/src/components/Restaurants/AutocompleteList/AutocompleteList.css
@@ -1,0 +1,4 @@
+.autocompletelist {
+    margin-bottom: 1em;
+    margin-top: 0em;
+}

--- a/packages/app/src/components/Restaurants/AutocompleteList/AutocompleteList.js
+++ b/packages/app/src/components/Restaurants/AutocompleteList/AutocompleteList.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import { Card } from 'react-bootstrap'
+import PropTypes from 'prop-types'
+
+import AutocompleteEntry from '../AutocompleteEntry/AutocompleteEntry'
+
+import './AutocompleteList.css'
+
+const AutocompleteList = ({ suggestions, handleClick }) => {
+  return (
+    <Card data-testid='autocomplete-list' className="autocompletelist">
+      {suggestions.map(suggestion => <AutocompleteEntry key={suggestion.placeId} suggestion={suggestion} handleClick={handleClick} />)}
+    </Card>
+  )
+}
+
+AutocompleteList.propTypes = {
+  suggestions: PropTypes.array.isRequired,
+  handleClick: PropTypes.func.isRequired
+}
+
+export default AutocompleteList

--- a/packages/app/src/components/Restaurants/EditForm.js
+++ b/packages/app/src/components/Restaurants/EditForm.js
@@ -32,8 +32,9 @@ const EditForm = ({ id }) => {
             ...fetched,
             name: fetched.name || '',
             url: fetched.url || '',
+            address: fetched.address || '',
             categories: fetched.categories || [],
-            showMap: true
+            coordinates: fetched.coordinates || undefined,
           })
           setError()
         })
@@ -63,7 +64,8 @@ const EditForm = ({ id }) => {
       setRestaurant={setRestaurant}
       onSubmit={handleSubmit}
       submitMessage={!isLoggedIn ? 'Suggest' : 'Update'}
-      suggestTooltip={'Send a suggestion to edit this restaurant'} />
+      suggestTooltip={'Send a suggestion to edit this restaurant'}
+    />
 }
 
 EditForm.propTypes = {

--- a/packages/app/src/components/Restaurants/EditForm.test.js
+++ b/packages/app/src/components/Restaurants/EditForm.test.js
@@ -7,6 +7,9 @@ import suggestionService from '../../services/suggestion'
 import categoryService from '../../services/category'
 import authService from '../../services/authentication'
 import locationService from '../../services/location'
+import placeService from '../../services/places'
+
+import testdata from '../../util/testData'
 
 import { actRender } from '../../test/utilities'
 import { act } from 'react-dom/test-utils'
@@ -16,6 +19,9 @@ jest.mock('../../services/suggestion.js')
 jest.mock('../../services/category.js')
 jest.mock('../../services/location.js')
 jest.mock('../../services/authentication.js')
+jest.mock('../../services/places.js')
+
+jest.useFakeTimers()
 
 beforeEach(() => {
   jest.clearAllMocks()
@@ -30,6 +36,8 @@ beforeEach(() => {
     from: { lat: 60.17, lon: 24.941944 },
     to: { lat: 60.182315, lon: 24.922893 }
   })
+  placeService.getSuggestions.mockResolvedValue(testdata.getSuggestions())
+  placeService.getRestaurant.mockResolvedValue(testdata.getRestaurant())
 })
 
 test('form is not rendered if restaurant cannot be found', async () => {
@@ -51,9 +59,10 @@ test('form is pre-filled if a restaurant is found with the given id parameter', 
     {
       name: 'Luigi\'s pizza',
       url: 'www.pizza.fi',
+      address: 'Kotikatu 1 a',
       id: 1,
       categories: [],
-      coordinates: {latitude: 60, longitude: 24}
+      coordinates: { latitude: 60, longitude: 24 }
     }
   )
 
@@ -73,9 +82,10 @@ describe('when logged in', () => {
   test('pressing submit makes call to restaurant service', async () => {
     const edited = {
       name: 'Luigin pitseria',
+      address: 'kotikatu 1 a',
       url: 'www.pitsa.fi',
       categories: [],
-      coordinates: {latitude: 69, longitude: 42}
+      coordinates: { latitude: 60, longitude: 24 }
     }
 
     authService.getToken.mockReturnValue('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjVlNDUzYmFlNjZiYjNkMjUxZGMwM2U5YyIsInVzZXJuYW1lIjoiTWFrZSIsImlhdCI6MTU4MTU5OTg5MX0.0BDsns4hxWvMguZq8llaB3gMTvPNDkDhPkl7mCYl928')
@@ -83,10 +93,11 @@ describe('when logged in', () => {
     restaurantService.getOneById.mockResolvedValue(
       {
         name: 'Luigi\'s pizza',
+        address: 'kotikatu 1 a',
         url: 'www.pizza.fi',
         id: 1,
         categories: [],
-        coordinates: {latitude: 60, longitude: 24}
+        coordinates: { latitude: 60, longitude: 24 }
       }
     )
 
@@ -102,9 +113,7 @@ describe('when logged in', () => {
     fireEvent.change(nameField, { target: { value: edited.name } })
     fireEvent.change(urlField, { target: { value: edited.url } })
 
-    const checkElement = within(form).getByTestId(/check-button/i)
     const buttonElement = within(form).getByTestId(/submit-button/i)
-    await act(async () => fireEvent.click(checkElement))
     await act(async () => fireEvent.click(buttonElement))
 
     expect(restaurantService.update).toBeCalledWith(expect.objectContaining({
@@ -119,9 +128,10 @@ describe('when not logged in', () => {
     const edited = {
       name: 'Luigin pitseria',
       url: 'www.pitsa.fi',
+      address: 'kotikatu 1 a',
       id: 1,
       categories: [],
-      coordinates: {latitude: 69, longitude: 42}
+      coordinates: { latitude: 60, longitude: 24 }
     }
 
     restaurantService.add.mockResolvedValue({ ...edited })
@@ -130,9 +140,10 @@ describe('when not logged in', () => {
       {
         name: 'Luigi\'s pizza',
         url: 'www.pizza.fi',
+        address: 'kotikatu 1 a',
         id: 1,
         categories: [],
-        coordinates: {latitude: 60, longitude: 24}
+        coordinates: { latitude: 60, longitude: 24 }
       }
     )
 
@@ -148,9 +159,7 @@ describe('when not logged in', () => {
     fireEvent.change(nameField, { target: { value: edited.name } })
     fireEvent.change(urlField, { target: { value: edited.url } })
 
-    const checkElement = within(form).getByTestId(/check-button/i)
     const buttonElement = within(form).getByTestId(/submit-button/i)
-    await act(async () => fireEvent.click(checkElement))
     await act(async () => fireEvent.click(buttonElement))
 
     expect(suggestionService.editRestaurant).toBeCalledWith(expect.objectContaining({ ...edited }))
@@ -162,6 +171,7 @@ test('map is shown by default in the edit form', async () => {
     {
       name: 'Luigi\'s pizza',
       url: 'www.pizza.fi',
+      address: 'kotikatu 1 a',
       id: 1,
       categories: [],
       coordinates: { latitude: 60, longitude: 24 }
@@ -176,6 +186,7 @@ test('map is not shown if the address is changed', async () => {
     {
       name: 'Luigi\'s pizza',
       url: 'www.pizza.fi',
+      address: 'kotikatu 1 a',
       id: 1,
       categories: [],
       coordinates: { latitude: 60, longitude: 24 }
@@ -194,6 +205,7 @@ test('map is shown if the address is changed and checked', async () => {
     {
       name: 'Luigi\'s pizza',
       url: 'www.pizza.fi',
+      address: 'kotikatu 1 a',
       id: 1,
       categories: [],
       coordinates: { latitude: 60, longitude: 24 }

--- a/packages/app/src/components/Restaurants/form/RestaurantForm.css
+++ b/packages/app/src/components/Restaurants/form/RestaurantForm.css
@@ -22,3 +22,12 @@
 .btn-toolbar {
     justify-content: space-between;
 }
+
+.name-field:focus {
+    margin-bottom: 0em;
+}
+
+.address-field {
+    display:flex;
+    flex-direction: row;
+}

--- a/packages/app/src/components/Restaurants/form/RestaurantForm.test.js
+++ b/packages/app/src/components/Restaurants/form/RestaurantForm.test.js
@@ -16,8 +16,6 @@ jest.mock('../../../services/category.js')
 jest.mock('../../../services/location.js')
 jest.mock('../../../services/places.js')
 
-
-
 const createEmptyRestaurant = () => ({ name: '', url: '', categories: [] })
 
 beforeEach(() => {
@@ -437,7 +435,7 @@ test('map is shown when the restaurant has coordinates true (i.e. when editing a
 })
 
 
-test('name field text input calls placeService.getSuggestions() TOIMII', async () => {
+test('name field text input calls placeService.getSuggestions()', async () => {
   const mockSetRestaurant = jest.fn()
   const { getByTestId } = await actRender(
     <RestaurantForm
@@ -456,8 +454,10 @@ test('name field text input calls placeService.getSuggestions() TOIMII', async (
   await wait(() => expect(placeService.getSuggestions).toBeCalledWith('Lidl City Center'))
 })
 
-test.skip('name field text input leads to suggestions being rendered EI TOIMI', async () => {
+test('name field text input leads to suggestions being rendered', async () => {
   const mockSetRestaurant = jest.fn()
+  placeService.getSuggestions.mockResolvedValue(testdata.getSuggestions().data)
+
   const { getByTestId, queryByTestId } = await actRender(
     <RestaurantForm
       restaurant={createEmptyRestaurant()}
@@ -465,22 +465,27 @@ test.skip('name field text input leads to suggestions being rendered EI TOIMI', 
       error={''}
       setError={jest.fn()}
       onSubmit={jest.fn()}
-    />)
+    />
+  )
+
   jest.useFakeTimers()
   const form = getByTestId(/restaurant-form/i)
   const nameField = within(form).getByTestId(/name-field/i)
   const nameElement = within(nameField).getByRole(/textbox/i)
   fireEvent.change(nameElement, { target: { value: 'Lidl City Center' } })
+  fireEvent.focus(nameElement)
   jest.runAllTimers()
+
+  expect(nameElement).toMatchObject(document.activeElement)
   await wait(() => expect(placeService.getSuggestions).toBeCalledWith('Lidl City Center'))
-  act(() => nameElement.focus())
-  console.log(document.activeElement)
   expect(queryByTestId('autocomplete-list')).toBeInTheDocument()
   await wait(() => expect(queryByTestId('autocomplete-entry')).toBeInTheDocument())
 })
 
-test.skip('clicking on a suggestion calls placeService.getRestaurant EI TOIMI', async () => {
+test('clicking on a suggestion calls placeService.getRestaurant', async () => {
   const mockSetRestaurant = jest.fn()
+  placeService.getSuggestions.mockResolvedValue(testdata.getSuggestions().data)
+
   const { getByTestId, queryByTestId } = await actRender(
     <RestaurantForm
       restaurant={createEmptyRestaurant()}
@@ -488,17 +493,23 @@ test.skip('clicking on a suggestion calls placeService.getRestaurant EI TOIMI', 
       error={''}
       setError={jest.fn()}
       onSubmit={jest.fn()}
-    />)
+    />
+  )
+
   jest.useFakeTimers()
   const form = getByTestId(/restaurant-form/i)
   const nameField = within(form).getByTestId(/name-field/i)
   const nameElement = within(nameField).getByRole(/textbox/i)
   fireEvent.change(nameElement, { target: { value: 'Lidl City Center' } })
+  fireEvent.focus(nameElement)
   jest.runAllTimers()
+
   await wait(() => expect(placeService.getSuggestions).toBeCalledWith('Lidl City Center'))
   await wait(() => expect(queryByTestId('autocomplete-list')).toBeInTheDocument())
-  await wait(() => expect(queryByTestId('autocomplete-entry')).toBeInTheDocument())
-  const suggestionElement = getByTestId('autocomplete-entry')
-  fireEvent.click(suggestionElement)
+  await wait(() => {
+    const suggestionElement = queryByTestId('autocomplete-entry')
+    expect(suggestionElement).toBeInTheDocument()
+    fireEvent.click(suggestionElement)
+  })
   await wait(() => expect(placeService.getRestaurant).toBeCalledWith('ChIJgWk_zoQJkkYRr0Ye0Tk7DF4'))
 })

--- a/packages/app/src/components/Restaurants/form/RestaurantForm.test.js
+++ b/packages/app/src/components/Restaurants/form/RestaurantForm.test.js
@@ -1,16 +1,24 @@
 import React from 'react'
-import { fireEvent, within, act } from '@testing-library/react'
+import { fireEvent, within, wait } from '@testing-library/react'
 import RestaurantForm from './RestaurantForm'
 
 import categoryService from '../../../services/category'
 import locationService from '../../../services/location'
+import placeService from '../../../services/places'
+
+import testdata from '../../../util/testData'
+
+import { act } from 'react-dom/test-utils'
 
 import { actRender } from '../../../test/utilities'
 
 jest.mock('../../../services/category.js')
 jest.mock('../../../services/location.js')
+jest.mock('../../../services/places.js')
 
-const createEmptyRestaurant = () => ({ name: '', url: '', categories: [], showMap: false})
+
+
+const createEmptyRestaurant = () => ({ name: '', url: '', categories: [] })
 
 beforeEach(() => {
   jest.clearAllMocks()
@@ -24,6 +32,8 @@ beforeEach(() => {
     from: { lat: 60.17, lon: 24.941944 },
     to: { lat: 60.182315, lon: 24.922893 }
   })
+  placeService.getSuggestions.mockResolvedValue(testdata.getSuggestions())
+  placeService.getRestaurant.mockResolvedValue(testdata.getRestaurant())
 })
 
 describe('form alerts', () => {
@@ -83,7 +93,7 @@ describe('form alerts', () => {
   test('invalid url input displays an error message', async () => {
     const { getByTestId } = await actRender(
       <RestaurantForm
-        restaurant={createEmptyRestaurant()}
+        restaurant={{ ...createEmptyRestaurant(), url: 'bb' }}
         setRestaurant={jest.fn()}
         error={''}
         setError={jest.fn()}
@@ -120,9 +130,8 @@ test('name field accepts text input', async () => {
   const nameElement = within(nameField).getByRole(/textbox/i)
   fireEvent.change(nameElement, { target: { value: 'Lidl City Center' } })
 
-  expect(mockSetRestaurant).toBeCalledWith({ name: 'Lidl City Center', url: '', categories: [], showMap: false })
+  expect(mockSetRestaurant).toBeCalledWith({ name: 'Lidl City Center', url: '', categories: [] })
 })
-
 test('url field accepts text input', async () => {
   const mockSetRestaurant = jest.fn()
   const { getByTestId } = await actRender(
@@ -141,7 +150,7 @@ test('url field accepts text input', async () => {
   const nameElement = within(urlField).getByRole(/textbox/i)
   fireEvent.change(nameElement, { target: { value: 'https://www.lidl.fi/' } })
 
-  expect(mockSetRestaurant).toBeCalledWith({ name: '', url: 'https://www.lidl.fi/', categories: [], showMap:false })
+  expect(mockSetRestaurant).toBeCalledWith({ name: '', url: 'https://www.lidl.fi/', categories: [] })
 })
 
 test('address field accepts text input', async () => {
@@ -174,7 +183,6 @@ test('pressing cancel hides the component', async () => {
         name: 'Lidl City Center',
         url: 'https://www.lidl.fi/',
         categories: [],
-        showMap: false
       }}
       setRestaurant={jest.fn()}
       error={''}
@@ -202,11 +210,7 @@ test('pressing check when address can be resolved calls setRestaurant with coord
         address: 'Jokukatu 42',
         categories: [],
         distance: 1000,
-        coordinates: {
-          latitude: 60,
-          longitude: 24,
-        },
-        showMap: false
+        coordinates: undefined
       }}
       setRestaurant={mockSetRestaurant}
       error={''}
@@ -229,7 +233,6 @@ test('pressing check when address can be resolved calls setRestaurant with coord
       longitude: 42,
     },
     distance: 1234,
-    showMap: true
   }))
 })
 
@@ -246,11 +249,7 @@ describe('when restaurant is not validated', () => {
           address: 'Jokukatu 42',
           categories: [],
           distance: 1234,
-          coordinates: {
-            latitude: 69,
-            longitude: 42,
-          },
-          showMap: false
+          coordinates: undefined
         }}
         setRestaurant={jest.fn()}
         error={''}
@@ -278,11 +277,7 @@ describe('when restaurant is not validated', () => {
           address: 'Jokukatu 42',
           categories: [],
           distance: 1234,
-          coordinates: {
-            latitude: 69,
-            longitude: 42,
-          },
-          showMap: true
+          coordinates: undefined
         }}
         setRestaurant={jest.fn()}
         error={''}
@@ -312,11 +307,7 @@ describe('when restaurant is validated', () => {
           address: 'Jokukatu 42',
           categories: [],
           distance: 1234,
-          coordinates: {
-            latitude: 69,
-            longitude: 42,
-          },
-          showMap: false
+          coordinates: undefined
         }}
         setRestaurant={jest.fn()}
         error={''}
@@ -336,10 +327,7 @@ describe('when restaurant is validated', () => {
       url: 'https://www.lidl.fi/',
       categories: [],
       address: 'Jokukatu 42',
-      coordinates: {
-        latitude: 69,
-        longitude: 42,
-      },
+      coordinates: undefined,
       distance: 1234
     }))
   })
@@ -356,11 +344,7 @@ describe('when restaurant is validated', () => {
           address: 'Jokukatu 42',
           categories: [],
           distance: 1234,
-          coordinates: {
-            latitude: 69,
-            longitude: 42,
-          },
-          showMap: false
+          coordinates: undefined
         }}
         setRestaurant={jest.fn()}
         error={''}
@@ -394,8 +378,7 @@ describe('when restaurant is validated', () => {
           name: 'Lidl City Center',
           url: 'https://www.lidl.fi/',
           address: 'Jokukatu 42',
-          categories: [],
-          showMap: false
+          categories: []
         }}
         setRestaurant={jest.fn()}
         error={''}
@@ -414,7 +397,7 @@ describe('when restaurant is validated', () => {
   })
 })
 
-test('map is not shown when the restaurant has showMap false)', async () => {
+test('map is not shown when the restaurant has no coordinates)', async () => {
   const { queryByTestId } = await actRender(
     <RestaurantForm
       restaurant={{
@@ -423,8 +406,7 @@ test('map is not shown when the restaurant has showMap false)', async () => {
         address: 'Jokukatu 42',
         categories: [],
         distance: 1234,
-        coordinates: {latitude: 60, longitude: 24},
-        showMap: false
+        coordinates: undefined
       }}
       setRestaurant={jest.fn()}
       error={''}
@@ -435,7 +417,7 @@ test('map is not shown when the restaurant has showMap false)', async () => {
 })
 
 
-test('map is shown when the restaurant has showMap true (i.e. when editing an existing restaurant, or after successful address check)', async () => {
+test('map is shown when the restaurant has coordinates true (i.e. when editing an existing restaurant, or after successful address check)', async () => {
   const { queryByTestId } = await actRender(
     <RestaurantForm
       restaurant={{
@@ -445,7 +427,6 @@ test('map is shown when the restaurant has showMap true (i.e. when editing an ex
         categories: [],
         distance: 1234,
         coordinates: { latitude: 60.182315, longitude: 24.922893 },
-        showMap: true
       }}
       setRestaurant={jest.fn()}
       error={''}
@@ -453,4 +434,71 @@ test('map is shown when the restaurant has showMap true (i.e. when editing an ex
       onSubmit={jest.fn()}
     />)
   expect(queryByTestId('map')).toBeInTheDocument()
+})
+
+
+test('name field text input calls placeService.getSuggestions() TOIMII', async () => {
+  const mockSetRestaurant = jest.fn()
+  const { getByTestId } = await actRender(
+    <RestaurantForm
+      restaurant={createEmptyRestaurant()}
+      setRestaurant={mockSetRestaurant}
+      error={''}
+      setError={jest.fn()}
+      onSubmit={jest.fn()}
+    />)
+  jest.useFakeTimers()
+  const form = getByTestId(/restaurant-form/i)
+  const nameField = within(form).getByTestId(/name-field/i)
+  const nameElement = within(nameField).getByRole(/textbox/i)
+  fireEvent.change(nameElement, { target: { value: 'Lidl City Center' } })
+  jest.runAllTimers()
+  await wait(() => expect(placeService.getSuggestions).toBeCalledWith('Lidl City Center'))
+})
+
+test.skip('name field text input leads to suggestions being rendered EI TOIMI', async () => {
+  const mockSetRestaurant = jest.fn()
+  const { getByTestId, queryByTestId } = await actRender(
+    <RestaurantForm
+      restaurant={createEmptyRestaurant()}
+      setRestaurant={mockSetRestaurant}
+      error={''}
+      setError={jest.fn()}
+      onSubmit={jest.fn()}
+    />)
+  jest.useFakeTimers()
+  const form = getByTestId(/restaurant-form/i)
+  const nameField = within(form).getByTestId(/name-field/i)
+  const nameElement = within(nameField).getByRole(/textbox/i)
+  fireEvent.change(nameElement, { target: { value: 'Lidl City Center' } })
+  jest.runAllTimers()
+  await wait(() => expect(placeService.getSuggestions).toBeCalledWith('Lidl City Center'))
+  act(() => nameElement.focus())
+  console.log(document.activeElement)
+  expect(queryByTestId('autocomplete-list')).toBeInTheDocument()
+  await wait(() => expect(queryByTestId('autocomplete-entry')).toBeInTheDocument())
+})
+
+test.skip('clicking on a suggestion calls placeService.getRestaurant EI TOIMI', async () => {
+  const mockSetRestaurant = jest.fn()
+  const { getByTestId, queryByTestId } = await actRender(
+    <RestaurantForm
+      restaurant={createEmptyRestaurant()}
+      setRestaurant={mockSetRestaurant}
+      error={''}
+      setError={jest.fn()}
+      onSubmit={jest.fn()}
+    />)
+  jest.useFakeTimers()
+  const form = getByTestId(/restaurant-form/i)
+  const nameField = within(form).getByTestId(/name-field/i)
+  const nameElement = within(nameField).getByRole(/textbox/i)
+  fireEvent.change(nameElement, { target: { value: 'Lidl City Center' } })
+  jest.runAllTimers()
+  await wait(() => expect(placeService.getSuggestions).toBeCalledWith('Lidl City Center'))
+  await wait(() => expect(queryByTestId('autocomplete-list')).toBeInTheDocument())
+  await wait(() => expect(queryByTestId('autocomplete-entry')).toBeInTheDocument())
+  const suggestionElement = getByTestId('autocomplete-entry')
+  fireEvent.click(suggestionElement)
+  await wait(() => expect(placeService.getRestaurant).toBeCalledWith('ChIJgWk_zoQJkkYRr0Ye0Tk7DF4'))
 })

--- a/packages/app/src/components/RouteMap/RouteMap.js
+++ b/packages/app/src/components/RouteMap/RouteMap.js
@@ -11,14 +11,18 @@ const RouteMap = ({ restaurant }) => {
   const [positions, setPositions] = useState()
 
   useEffect(() => {
+    let mounted = true
     const getMapData = async () => {
       const leg = await locationService.getLeg(restaurant.coordinates.latitude, restaurant.coordinates.longitude)
-      setStart([locationService.unityLat, locationService.unityLon])
-      setEnd([restaurant.coordinates.latitude, restaurant.coordinates.longitude])
-      setBounds(locationService.calculateBounds(leg))
-      setPositions(locationService.decodeRoute(leg.legGeometry.points))
+      if (mounted) {
+        setStart([locationService.unityLat, locationService.unityLon])
+        setEnd([restaurant.coordinates.latitude, restaurant.coordinates.longitude])
+        setBounds(locationService.calculateBounds(leg))
+        setPositions(locationService.decodeRoute(leg.legGeometry.points))
+      }
     }
     getMapData()
+    return () => mounted = false
   }, [restaurant])
 
   return (
@@ -72,7 +76,7 @@ RouteMap.propTypes = {
   restaurant: PropTypes.shape({
     id: PropTypes.any,
     name: PropTypes.string.isRequired,
-    url: PropTypes.string.isRequired,
+    url: PropTypes.string,
     categories: PropTypes.array,
     address: PropTypes.string,
     coordinates: PropTypes.shape({

--- a/packages/app/src/services/places.js
+++ b/packages/app/src/services/places.js
@@ -1,0 +1,21 @@
+import axios from 'axios'
+import testdata from '../util/testData'
+const baseUrl = '/api/places'
+
+const testing = false
+
+const getSuggestions = async (text) => {
+  const suggestions = testing
+    ? testdata.getSuggestions()
+    : await axios.get(`${baseUrl}/autocomplete/${text}`)
+  return suggestions.data
+}
+
+const getRestaurant = async (id) => {
+  const restaurant = testing
+    ? testdata.getRestaurant()
+    : await axios.get(`${baseUrl}/details/addform/${id}`)
+  return restaurant.data.result
+}
+
+export default { getSuggestions, getRestaurant }

--- a/packages/app/src/util/customHooks.js
+++ b/packages/app/src/util/customHooks.js
@@ -1,0 +1,20 @@
+import React from 'react'
+
+const useActiveElement = () => {
+  const [active, setActive] = React.useState(document.activeElement)
+
+  const handleFocusIn = () => {
+    setActive(document.activeElement)
+  }
+
+  React.useEffect(() => {
+    document.addEventListener('focusin', handleFocusIn)
+    return () => {
+      document.removeEventListener('focusin', handleFocusIn)
+    }
+  }, [])
+
+  return active
+}
+
+export default { useActiveElement }

--- a/packages/app/src/util/testData.js
+++ b/packages/app/src/util/testData.js
@@ -1,0 +1,103 @@
+const getSuggestions = () => {
+  return (
+    {
+      data: [
+        {
+          name: 'Caverna Restaurant',
+          address: 'Caverna Restaurant, Yliopistonkatu, Helsinki, Finland',
+          distance: 265,
+          placeId: 'ChIJgWk_zoQJkkYRr0Ye0Tk7DF4',
+        }]
+    }
+  )
+}
+
+const getRestaurant = () => {
+  return (
+    {
+      data: {
+        result: {
+          formatted_address: 'Yliopistonkatu 5, 00100 Helsinki, Finland',
+          geometry: {
+            location: {
+              lat: 60.16990200000001,
+              lng: 24.9467298
+            },
+            viewport: {
+              northeast: {
+                lat: 60.1712086802915,
+                lng: 24.94808478029151
+              },
+              southwest: {
+                lat: 60.16851071970849,
+                lng: 24.9453868197085
+              }
+            },
+          },
+          name: 'Caverna Restaurant',
+          opening_hours: {
+            open_now: true,
+            periods: [
+              {
+                close: { day: 0, time: '1900' },
+                open: { day: 0, time: '1200' }
+              },
+              {
+                close: { day: 0, time: '1900' },
+                open: { day: 0, time: '1200' }
+              },
+              {
+                close: { day: 0, time: '1900' },
+                open: { day: 0, time: '1200' }
+              },
+              {
+                close: { day: 0, time: '1900' },
+                open: { day: 0, time: '1200' }
+              },
+              {
+                close: { day: 0, time: '1900' },
+                open: { day: 0, time: '1200' }
+              },
+              {
+                close: { day: 0, time: '1900' },
+                open: { day: 0, time: '1200' }
+              },
+              {
+                close: { day: 0, time: '1900' },
+                open: { day: 0, time: '1200' }
+              }
+            ],
+            weekday_text: [
+              'Monday: 11:00 AM – 9:00 PM',
+              'Tuesday: 11:00 AM – 9:00 PM',
+              'Wednesday: 11:00 AM – 10:00 PM',
+              'Thursday: 11:00 AM – 10:00 PM',
+              'Friday: 11:00 AM – 12:00 AM',
+              'Saturday: 12:00 PM – 12:00 AM',
+              'Sunday: 12:00 – 7:00 PM',
+            ]
+          },
+          photos: [
+            {
+              height: 3648,
+              html_attributions: ['<a href=\'https://maps.google.com/maps/contrib/109132722862630807631\'>Caverna Restaurant</a>'],
+              photo_reference: 'CmRaAAAA6N9BkN-9d8TSJ6zPmeauOJ3ckv99LmT1h1ck6Ntcjx0a_xGRgo-Py9yz0H3l2I_22JFIiucI5RfhnNzPhgmJ77ydgCq4cQfc-MkOIDDdCI64d4mFux8tRqKtzTPMk8t3EhCLPN6C28u9M7hR8MQCxsakGhSEssRPxL7djdPKi023rTlIwvxySQ',
+              width: 5472,
+            },
+            {
+              height: 315,
+              html_attributions: ['<a href=\'https://maps.google.com/maps/contrib/109132722862630807631\'>Caverna Restaurant</a>'],
+              photo_reference: 'CmRaAAAAABySUYqnq_y6FSzgHhgqrkEGKSirVzEPObvJbJlrlQ2_4MZLCnHzppOvzi6ZUZNIF0uIacA6r1E2V8Jw303iGlZ3p2fh-W9TAk8HOpV_Fp_ZR4OSWsTl_SWn5wngpT2iEhDN6AbO4h9AnSuzekez7dXgGhR5YFQkSmA4b4JHGonm1mANxWODQA',
+              width: 851
+            }
+          ],
+          place_id: 'ChIJgWk_zoQJkkYRr0Ye0Tk7DF4',
+          website: 'http://www.caverna.fi/'
+        }
+      }
+    }
+  )
+}
+
+
+export default { getSuggestions, getRestaurant }

--- a/packages/backend/src/controllers/places.js
+++ b/packages/backend/src/controllers/places.js
@@ -61,11 +61,28 @@ placesRouter.get('/details/reviews/:place_id', async (request, response, next) =
   }
 })
 
+placesRouter.get('/details/addform/:place_id', async (request, response, next) => {
+  try {
+    const fields = 'formatted_address,name,place_id,geometry,website'
+    const placeId = request.params.place_id
+    const details = await google.findDetails(placeId, fields)
+    if (details === null) {
+      return response.status(404).send({ error: 'No places found with the given place id' })
+    }
+
+    return response.status(200).send(details)
+  } catch (error) {
+    next(error)
+  }
+})
+
 placesRouter.get('/autocomplete/:name', async (request, response, next) => {
   try {
+    const foodTypes = ['food', 'restaurant', 'bar', 'cafe', 'casino', 'meal_delivery', 'meal_takeaway']
+    const servesFood = (type) => foodTypes.includes(type)
     const text = request.params.name
-
-    const predictions = await google.autocomplete(text)
+    let predictions = await google.autocomplete(text)   
+    predictions = predictions.filter(prediction => prediction.types.some(servesFood))
 
     const result = predictions
       .map(prediction => ({

--- a/packages/backend/src/controllers/restaurants.js
+++ b/packages/backend/src/controllers/restaurants.js
@@ -79,7 +79,8 @@ const parseRestaurant = (body, id) => {
   const distance = body.distance
   const url = trimAndUndefineIfEmpty(body.url)
   const categories = body.categories || []
-  return { id, name, url, categories, address, coordinates, distance }
+  const placeId = body.placeId || undefined
+  return { id, name, url, categories, address, coordinates, distance, placeId }
 }
 
 // getAll

--- a/packages/backend/src/controllers/restaurants.test.js
+++ b/packages/backend/src/controllers/restaurants.test.js
@@ -407,13 +407,53 @@ describe('when logged in', () => {
       .expect(204)
   })
 
+  test('post request with a placeId creates the restaurant with a placeId', async () => {
+
+    const response = await server
+      .post(`/api/restaurants/`)
+      .set('authorization', `bearer ${token}`)
+      .send({ name: 'Torigrilli Senaatintori', url: 'https://torigrilli.fi', categories: [], address: 'Senaatintori', coordinates: { latitude: 60, longitude: 24 }, distance: 1000, placeId: 'ChIJgWk_zoQJkkYRr0Ye0Tk7DF4' })
+      .expect(201)
+
+    const restaurant = response.body
+    expect(restaurant).toMatchObject({
+      name: 'Torigrilli Senaatintori',
+      url: 'https://torigrilli.fi',
+      categories: [],
+      address: 'Senaatintori',
+      coordinates: { latitude: 60, longitude: 24 },
+      distance: 1000,
+      placeId: 'ChIJgWk_zoQJkkYRr0Ye0Tk7DF4' 
+    })
+  })
+
+  test('post request without a placeId creates the restaurant without a placeId', async () => {
+
+    const response = await server
+      .post(`/api/restaurants/`)
+      .set('authorization', `bearer ${token}`)
+      .send({ name: 'Torigrilli Senaatintori', url: 'https://torigrilli.fi', categories: [], address: 'Senaatintori', coordinates: { latitude: 60, longitude: 24 }, distance: 1000 })
+      .expect(201)
+
+    const restaurant = response.body
+    expect(restaurant).toMatchObject({
+      name: 'Torigrilli Senaatintori',
+      url: 'https://torigrilli.fi',
+      categories: [],
+      address: 'Senaatintori',
+      coordinates: { latitude: 60, longitude: 24 },
+      distance: 1000
+    })
+    expect(restaurant.placeId).toBe(undefined)
+  })
+
   test('put request with valid data updates the restaurant', async () => {
     const testRestaurantId = restaurants[0].id
 
     await server
       .put(`/api/restaurants/${testRestaurantId}`)
       .set('authorization', `bearer ${token}`)
-      .send({ name: 'Torigrilli Senaatintori', url: 'https://torigrilli.fi', categories: [], address: 'Senaatintori', coordinates: { latitude: 60, longitude: 24 }, distance: 1000 })
+      .send({ name: 'Torigrilli Senaatintori', url: 'https://torigrilli.fi', categories: [], address: 'Senaatintori', coordinates: { latitude: 60, longitude: 24 }, distance: 1000, placeId: 'ChIJgWk_zoQJkkYRr0Ye0Tk7DF4' })
 
 
     const restaurant = await Restaurant.findById(testRestaurantId)
@@ -426,7 +466,8 @@ describe('when logged in', () => {
       coordinates: { latitude: 60, longitude: 24 },
       notSelectedAmount: 0,
       resultAmount: 0,
-      distance: 1000
+      distance: 1000,
+      placeId: 'ChIJgWk_zoQJkkYRr0Ye0Tk7DF4' 
     })
   })
 

--- a/packages/backend/src/controllers/restaurants.test.js
+++ b/packages/backend/src/controllers/restaurants.test.js
@@ -410,7 +410,7 @@ describe('when logged in', () => {
   test('post request with a placeId creates the restaurant with a placeId', async () => {
 
     const response = await server
-      .post(`/api/restaurants/`)
+      .post('/api/restaurants/')
       .set('authorization', `bearer ${token}`)
       .send({ name: 'Torigrilli Senaatintori', url: 'https://torigrilli.fi', categories: [], address: 'Senaatintori', coordinates: { latitude: 60, longitude: 24 }, distance: 1000, placeId: 'ChIJgWk_zoQJkkYRr0Ye0Tk7DF4' })
       .expect(201)
@@ -430,7 +430,7 @@ describe('when logged in', () => {
   test('post request without a placeId creates the restaurant without a placeId', async () => {
 
     const response = await server
-      .post(`/api/restaurants/`)
+      .post('/api/restaurants/')
       .set('authorization', `bearer ${token}`)
       .send({ name: 'Torigrilli Senaatintori', url: 'https://torigrilli.fi', categories: [], address: 'Senaatintori', coordinates: { latitude: 60, longitude: 24 }, distance: 1000 })
       .expect(201)

--- a/packages/backend/src/controllers/suggestions.js
+++ b/packages/backend/src/controllers/suggestions.js
@@ -29,7 +29,8 @@ const parseSuggestion = (body, type) => {
   const url = trimAndUndefineIfEmpty(body.url)
   const categories = body.categories || []
   const _id = body._id
-  const parsed = { type, data: { _id, name, url, categories, address, coordinates, distance } }
+  const placeId = body.placeId || undefined
+  const parsed = { type, data: { _id, name, url, categories, address, coordinates, distance, placeId } }
   return parsed
 }
 

--- a/packages/backend/src/controllers/suggestions.test.js
+++ b/packages/backend/src/controllers/suggestions.test.js
@@ -59,7 +59,8 @@ const getAdditionalSuggestions = () => [
       latitude: 26,
       longitude: 62
     },
-    distance: 1002
+    distance: 1002,
+    placeId: 'ChIJLxuNHssLkkYRE4g89GmS8_0'
   }
 ]
 

--- a/packages/backend/src/services/google.js
+++ b/packages/backend/src/services/google.js
@@ -8,7 +8,7 @@ const SEARCH_RADIUS = 10000 // in meters
 const LATITUDE = config.originLatitude
 const LONGITUDE = config.originLongitude
 
-const FIELDS = 'formatted_address,name,photos,opening_hours,permanently_closed,place_id,geometry'
+const FIELDS = 'formatted_address,name,photos,opening_hours,permanently_closed,place_id,geometry,website'
 
 /**
  * Thrown to indicate that the API key has exhausted its monthly quota.


### PR DESCRIPTION
- Typing in namefield fetches autocomplete suggestions (after 1 second timeout)
- Clicking on a suggestion fetches and populates the restaurant's details into the form.
- Changing the value in the name field undefines the placeId.
- Changing the address requires a new address check
- Restaurants can be posted without url, but if a url is provided it needs to be between 3 and 240 characters.
- Submit button is enabled by default when editing a restaurant (editing the address needs a new address check, editing the name undefines placeId).
- New Error checking instead of form-hook
- Check button moved to the address field
- Sending a restaurant suggestion / adding a restaurant adds placeId if it has been fetched