### PR TITLE
Photos endpoint

### DIFF
--- a/documentation/api/places.md
+++ b/documentation/api/places.md
@@ -80,6 +80,31 @@ Response body contains details of the requested place, as per [Google API docume
 }
 ```
 
-### Errors
- - `Status: 500 Internal Server Error` - if malformed ID is provided. Response body contains the error message.
+ - `Status: 404 Not Found` - if malformed or unknown ID is provided. Response body contains the error message.
+ - `Status: 503 Service Unavailable` - if the underlying Google API key has exhausted monthly quota
+
+
+`GET /api/places/details/photos/:place_id`
+--------------------------
+*"photos"* -endpoint; Given a valid Google Place ID, returns references to up to 10 photos of the corresponding place.
+
+### Response
+| Header         | value              |
+| -------------- | ------------------ |
+| `Content-Type` | `application/json` |
+| `Status Code`  | `200 OK`           |
+
+Response body contains information about the photos of the requested place. The application's google service sets the width to 400 pixels and the images will be scaled accordingly. The information includes the html attributions that have to be published with each image as well as the url for the photo. The binary data of the image is not returned. Go to [Google API documentation](https://developers.google.com/places/web-service/photos) for more information.
+
+```js
+{
+  "height": integer,
+  "html_attributions": [ /* HTML attributions */ ],
+  "photo_reference": string,
+  "width": integer,
+  "url": string 
+}
+```
+
+ - `Status: 404 Not Found` - if malformed or unknown ID is provided. Response body contains the error message.
  - `Status: 503 Service Unavailable` - if the underlying Google API key has exhausted monthly quota

--- a/packages/app/src/services/photo.js
+++ b/packages/app/src/services/photo.js
@@ -1,0 +1,9 @@
+import axios from 'axios'
+const baseUrl = '/api/places/details/photos'
+
+const getAllPhotosForRestaurant = async (placeId) => {
+  const response = await axios.get(`${baseUrl}/${placeId}`)
+  return response.data
+}
+
+export default { getAllPhotosForRestaurant }

--- a/packages/backend/src/controllers/places.js
+++ b/packages/backend/src/controllers/places.js
@@ -85,8 +85,11 @@ placesRouter.get('/details/photos/:place_id', async (request, response, next) =>
   const placeId = request.params.place_id
   
   try {
-    const urls = await google.getPhotoUrls(placeId)
-    return response.status(200).send(urls)
+    const photos = await google.getAllPhotos(placeId)
+    if (photos === null) {
+      return response.status(404).send({ error: 'No photos found.' })
+    }
+    return response.status(200).send(photos)
   } catch (error){
     next(error)
   }

--- a/packages/backend/src/controllers/places.js
+++ b/packages/backend/src/controllers/places.js
@@ -52,7 +52,7 @@ placesRouter.get('/details/reviews/:place_id', async (request, response, next) =
     const fields = 'rating,reviews'
     const details = await google.findDetails(placeId, fields)
     if (details === null) {
-      return response.status(404).send({ error: 'No places found with the given place id' })
+      return response.status(404).send({ error: 'No reviews found with the given place id' })
     }
 
     return response.status(200).send(details)

--- a/packages/backend/src/controllers/places.js
+++ b/packages/backend/src/controllers/places.js
@@ -81,4 +81,15 @@ placesRouter.get('/autocomplete/:name', async (request, response, next) => {
   }
 })
 
+placesRouter.get('/details/photos/:place_id', async (request, response, next) => {
+  const placeId = request.params.place_id
+  
+  try {
+    const urls = await google.getPhotoUrls(placeId)
+    return response.status(200).send(urls)
+  } catch (error){
+    next(error)
+  }
+})
+
 module.exports = placesRouter

--- a/packages/backend/src/controllers/places.test.js
+++ b/packages/backend/src/controllers/places.test.js
@@ -191,6 +191,18 @@ const reviewsResponse = {
   }
 }
 
+const photoResponse = [
+  {
+    'height': 2976,
+    'html_attributions': [
+      '<a href=\"https://maps.google.com/maps/contrib/109674951059360295476\">ilir berbatovci</a>'
+    ],
+    'photo_reference': 'CmRaAAAAno2XTIAtGVwF3ZUrwSDx2jJuTiKlRCT6zSBPPmB_tn-OJ8LiFWW1C0Wj85fnbK3VHhxvGht6F81ARnMYNGv4Z3TqcANf2RlnkYv8BixkzmoLexKIkwqU_-9QkeFwUOeQEhB3HC6bJDEwqLiGnjzrjzK8GhSDYRKkaUgQMlqKLm_gTWWPN5OTzQ',
+    'width': 3968,
+    'url': 'https://lh3.googleusercontent.com/p/AF1QipNywmFsAKDlkDz1bUyz0-c1o0UTC7L-uACgEObw=s1600-w400'
+  },
+]
+
 let server
 beforeEach(() => {
   jest.clearAllMocks()
@@ -284,7 +296,6 @@ test('find details returns some relevant information', async () => {
 
 test('details/reviews endpoint returns a rating and reviews for a restaurant', async () => {
   google.findDetails.mockResolvedValue(reviewsResponse)
-  console.log('test')
   const { body: contents } = await server
     .get(`/api/places/details/reviews/${detailsQuery}`)
   
@@ -297,4 +308,20 @@ test('details/reviews endpoint returns a rating and reviews for a restaurant', a
       }
     ]
   })
+})
+
+test('failed photo query returns with status 404', async () => {
+  google.getAllPhotos.mockResolvedValue(null)
+  await server
+    .get(`/api/places/details/photos/${detailsQuery}`)
+    .expect(404)
+})
+
+test('a successfull photo query returns meaningful data', async () => {
+  google.getAllPhotos.mockResolvedValue(photoResponse)
+  const response = await server
+    .get(`/api/places/details/photos/${detailsQuery}`)
+  
+  expect(response.status).toBe(200)
+  expect(response.body).toBeDefined()
 })

--- a/packages/backend/src/requests/photos_get.rest
+++ b/packages/backend/src/requests/photos_get.rest
@@ -1,0 +1,1 @@
+GET http://localhost:3001/api/places/details/photos/ChIJ1RRuq10KkkYRjnEI9JY4AQE HTTP/1.1

--- a/packages/backend/src/services/google.js
+++ b/packages/backend/src/services/google.js
@@ -62,6 +62,7 @@ const findDetails = async (placeId, fields) => {
   switch (response.data.status) {
     case 'ZERO_RESULTS':          // Place ID was valid but removed/hidden
     case 'NOT_FOUND':             // Place ID does not exist
+    case 'INVALID_REQUEST':       // Malformed Place ID
       return null
     case 'OK':                    // Place found and OK
       return {
@@ -115,21 +116,25 @@ const autocomplete = async (text) => {
 const getAllPhotos = async (placeId) => {
   const fields = 'photos'
   const details = await findDetails(placeId, fields)
+  if (details === null) {
+    return null
+  }
+
   const photoObjects = details.result.photos
 
   const modifiedList = await Promise.all(photoObjects.map(async photo => {
     return {...photo, url: await getUrl(photo.photo_reference)}
   }))
-  
+
   return modifiedList
 }
 
 /**
  * Fetches a url for a photo from the Google Places Place Photos API. Returns a string containing the url.
  * 
- * The maxwidth parameter in the search url defines the maximum width for the photo. In this case, 
+ * The maxwidth parameter in the query defines the maximum width for the photo. In this case, 
  * photos wider than 400 pixels will be scaled to match the width while keeping its original aspect ratio.
- * The number must be between 1 and 1600. This parameter is also required for the request.
+ * The number must be between 1 and 1600. This parameter (or maxheight) is required for the request.
  * 
  * @param {string} reference The photo_reference attribute of the photo
  */

--- a/packages/backend/src/services/google.js
+++ b/packages/backend/src/services/google.js
@@ -103,10 +103,31 @@ const autocomplete = async (text) => {
   }
 }
 
+const getPhotoUrls = async (placeId) => {
+  try {
+    const fields = 'photos'
+    const details = await findDetails(placeId, fields)
+   
+    // details.result.photos -> taulukko photoja (height, html_attributions[],
+    // photo_reference, width)
+    
+    const photos = details.result.photos
+    const firstRef = photos[0].photo_reference
+
+    const result = await axios.get(`${baseUrl}/place/photo?maxwidth=400&photoreference=${firstRef}&key=${API_KEY}`)
+    const photoUrl = result.request._redirectable._options.href
+    return photoUrl
+
+  } catch (error) {
+    console.log(error)
+  }
+}
+
 
 module.exports = {
   findPlaceByKeyword,
   autocomplete,
   findDetails,
   QueryLimitError,
+  getPhotoUrls
 }


### PR DESCRIPTION
Front:

- A service ('photo') for retrieving photos with a placeId. response.data contains an array of photos (up to ten) with fields width, height, html_attributions[], photo_reference and url.
- Note: The width of every photo is set to 400 px in the backend (hard-coded query value) and the images the url:s lead to are scaled accordingly, keeping the original aspect ratio.

Back:

- A new endpoint '/details/photos/:placeId'
- A service 'getAllPhotos' (plus a helper 'getUrl') that communicates with the Google Places API
- basic tests

Also some fixes on documentation and responses.