### PR TITLE
Update CSS to fix the confetti positioning

### DIFF
--- a/packages/app/src/components/p5Components/Confetti/Confetti.css
+++ b/packages/app/src/components/p5Components/Confetti/Confetti.css
@@ -1,8 +1,14 @@
-.confetti > * > .p5Canvas {
+.confetti {
     position: absolute !important;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
+    z-index: 10 !important;
+    pointer-events: none;
+}
+
+.confetti > * > .p5Canvas {
+    position: relative !important;
     z-index: 10 !important;
     pointer-events: none;
 }

--- a/packages/app/src/scripts/confetti.js
+++ b/packages/app/src/scripts/confetti.js
@@ -8,8 +8,8 @@ import p5 from 'p5'
 
 const confetti = (sketch) => {
 
-  let width = sketch.windowWidth
-  let height = sketch.windowHeight
+  let width = sketch.windowWidth * 0.9
+  let height = sketch.windowHeight * 0.9
   let particles
   let opacity
   let gravity


### PR DESCRIPTION
- Adjusted CSS positioning
- Reduced the confetti canvas dimensions by 10% to prevent scrollbars from appearing

Tested browsers: Chrome, Firefox