### PR TITLE
Result approval buttons

### DIFF
--- a/documentation/api/restaurants.md
+++ b/documentation/api/restaurants.md
@@ -69,6 +69,19 @@ Endpoint for increasing resultAmount; Given an ID, increases value resultAmount 
 ### Errors
  - `Status: 404 Not Found` - if malformed or unknown ID is provided. Response body contains the error message.
 
+`PUT /api/restaurants/increaseSelected/:id`
+--------------------------
+Given an ID, increases the value of selectedAmount of corresponding *restaurant*. Represents the number of times users have picked this restaurant as the destination of their lunchtime excursions by clicking a button in the application.
+
+### Response
+| Header         | value              |
+| -------------- | ------------------ |
+| `Content-Type` | `application/json` |
+| `Status Code`  | `200 OK`           |
+
+### Errors
+ - `Status: 404 Not Found` - if malformed or unknown ID is provided. Response body contains the error message.
+
 `PUT /api/restaurants/increaseNotSelected/:id`
 --------------------------
 Endpoint for increasing notSelectedAmount; Given an ID, increases value notSelected of corresponding *restaurant*.

--- a/packages/app/src/components/Filter/Filter/Filter.js
+++ b/packages/app/src/components/Filter/Filter/Filter.js
@@ -21,7 +21,7 @@ const Filter = ({ filterCategories, setFilterCategories, filterType, setFilterTy
     <>
       {
         showFilter &&
-        <Card className='filter-container'>
+        <Card data-testid='filter-container' className='filter-container'>
           <Card.Header className='filter-title'> I only want restaurants that... </Card.Header>
           <Card.Body className='filter-typeselect' >
             <InputGroup>

--- a/packages/app/src/components/Randomizer/Randomizer.css
+++ b/packages/app/src/components/Randomizer/Randomizer.css
@@ -19,3 +19,7 @@
     color:white; 
     border:none;
 }
+
+.randomizer-approveButton {
+    margin-bottom: 0.5em;
+}

--- a/packages/app/src/components/Randomizer/Randomizer.js
+++ b/packages/app/src/components/Randomizer/Randomizer.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { Button } from 'react-bootstrap'
-import { ExpandMore, ExpandLess } from '@material-ui/icons'
+import { ExpandMore, ExpandLess, ThumbUpAlt, ThumbDownAlt } from '@material-ui/icons'
 
 import RestaurantEntry from '../RestaurantEntry/RestaurantEntry'
 import Filter from '../Filter/Filter/Filter'
@@ -30,6 +30,7 @@ const Randomizer = ({
   const [restaurant, setRestaurant] = useState()
   const [iteration, setIteration] = useState(maxNumberOfRolls)
   const [isRolling, setRolling] = useState(false)
+  const [resultSelected, setResultSelected] = useState(false)
 
   const [filter, setFilter] = useState({
     type: 'some',
@@ -71,9 +72,16 @@ const Randomizer = ({
       : time
   }
 
+  const handleApproveResult = async () => {
+    if (restaurant && restaurant.id) {
+      await restaurantService.increaseSelectedAmount(restaurant.id)
+      setRestaurant({ ...restaurant, selectedAmount: restaurant.selectedAmount + 1 })
+      setResultSelected(true)
+    }
+  }
+
   const startRolling = async () => {
     if (restaurant && restaurant.id) {
-
       await restaurantService.increaseNotSelectedAmount(restaurant.id)
     }
     const restaurants = await restaurantService.getAllMatches(filter.type, filter.categories, filter.distance)
@@ -122,7 +130,19 @@ const Randomizer = ({
         ? <h1 data-testid='roll-label'>{restaurant.name}</h1>
         : <>
           <Confetti />
+          {resultSelected && <h1>No backing down now! You&apos;re having lunch at:</h1>}
           <RestaurantEntry restaurant={restaurant} showMap />
+          {!resultSelected &&
+            <Button
+              data-testid='randomizer-approveButton'
+              className='randomizer-approveButton'
+              onClick={handleApproveResult}
+              variant='success'
+              size='lg'>
+              <span>
+                <ThumbUpAlt /> Ok, I&apos;m picking this one!
+              </span>
+            </Button>}
         </>
       : <h1 data-testid='randomizer-resultLabel'>Hungry? Press the button!</h1>
   }
@@ -133,34 +153,38 @@ const Randomizer = ({
     <div data-testid='randomizer' className='randomizer'>
       {nope.active && <h1>NOPE</h1>}
       {selectRestaurantElement()}
-      <div data-testid='foodmodel-container' className='foodmodel' style={{display: `${(restaurant && !isRolling) ? 'none' : 'inline'}`}}>
+      <div data-testid='foodmodel-container' className='foodmodel' style={{ display: `${(restaurant && !isRolling) ? 'none' : 'inline'}` }}>
         <FoodModel rolling={isRolling} />
       </div>
-      <RandomizerButton
-        onClick={startRolling}
-        setError={setError}
-        isPicky={isPicky}
-        isRolling={isRolling}
-        hasResult={restaurant !== undefined && !isRolling}
-        maxNumberOfRolls={maxNumberOfRolls}
-        rollsRemaining={rollsRemaining}
-      />
-      <button
-        className='randomizer-showFilterButton'
-        onClick={() => setFilter({ ...filter, visible: !filter.visible })}>
-        {filter.visible ? 'Hide filter ' : 'Set filter '}
-        {filter.visible ? <ExpandLess /> : <ExpandMore />}
-      </button>
-      <Filter
-        emptyMessage={<strong>#IEatAnything</strong>}
-        filterCategories={filter.categories}
-        setFilterCategories={(value) => setFilter({ ...filter, categories: value })}
-        filterType={filter.type}
-        setFilterType={(value) => setFilter({ ...filter, type: value })}
-        distance={filter.distance}
-        setDistance={(value) => setFilter({ ...filter, distance: value })}
-        showFilter={filter.visible}
-      />
+      {!resultSelected &&
+        <>
+          <RandomizerButton
+            onClick={startRolling}
+            setError={setError}
+            isPicky={isPicky}
+            isRolling={isRolling}
+            hasResult={restaurant !== undefined && !isRolling}
+            maxNumberOfRolls={maxNumberOfRolls}
+            rollsRemaining={rollsRemaining}
+          />
+          <button
+            className='randomizer-showFilterButton'
+            onClick={() => setFilter({ ...filter, visible: !filter.visible })}>
+            {filter.visible ? 'Hide filter ' : 'Set filter '}
+            {filter.visible ? <ExpandLess /> : <ExpandMore />}
+          </button>
+          <Filter
+            emptyMessage={<strong>#IEatAnything</strong>}
+            filterCategories={filter.categories}
+            setFilterCategories={(value) => setFilter({ ...filter, categories: value })}
+            filterType={filter.type}
+            setFilterType={(value) => setFilter({ ...filter, type: value })}
+            distance={filter.distance}
+            setDistance={(value) => setFilter({ ...filter, distance: value })}
+            showFilter={filter.visible}
+          />
+        </>
+      }
     </div>
   )
 }
@@ -189,15 +213,15 @@ const RandomizerButton = ({
       ? 'Rolling!'
       : 'Wait for it...'
     : hasResult
-      ? 'Gimme another one!'
+      ? <span><ThumbDownAlt /> Nope, gimme another one!</span>
       : `I'm feeling ${isPicky ? 'picky' : 'lucky'}!`
 
   return (
     <Button
       data-testid='randomizer-randomizeButton'
       onClick={handleClick}
-      variant='success'
-      size='lg'
+      variant={hasResult ? 'secondary' : 'success'}
+      size={!hasResult && 'lg'}
       disabled={isRolling}>
       {label}
     </Button>

--- a/packages/app/src/components/Randomizer/Randomizer.test.js
+++ b/packages/app/src/components/Randomizer/Randomizer.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { fireEvent, act } from '@testing-library/react'
+import { fireEvent, act, wait } from '@testing-library/react'
 import { actRender } from '../../test/utilities'
 import Randomizer from './Randomizer'
 import restaurantService from '../../services/restaurant'
@@ -92,17 +92,40 @@ test('pressing the button calls the restaurant service', async () => {
   expect(restaurantService.getAllMatches).toBeCalled()
 })
 
-test('pressing the button calls the restaurant service to increase resultAmount', async () => {
+test('pressing the roll button calls the restaurant service to increase resultAmount', async () => {
   const { queryByTestId } = await actRender(<Randomizer />)
   await act(async () => fireEvent.click(queryByTestId(/randomizer-randomizeButton/i)))
   expect(restaurantService.increaseResultAmount).toBeCalled()
 })
 
-test('pressing the button a second time calls the restaurant service to increase notSelectedAmount', async () => {
+test('pressing the roll button a second time calls the restaurant service to increase notSelectedAmount', async () => {
   const { queryByTestId } = await actRender(<Randomizer />)
   await act(async () => fireEvent.click(queryByTestId(/randomizer-randomizeButton/i)))
   await act(async () => fireEvent.click(queryByTestId(/randomizer-randomizeButton/i)))
   expect(restaurantService.increaseNotSelectedAmount).toBeCalled()
+})
+
+test('the result approval button is rendered when the lottery result is shown', async () => {
+  const { queryByTestId } = await actRender(<Randomizer />)
+  await wait(() => fireEvent.click(queryByTestId(/randomizer-randomizeButton/i)))
+  const resultApproveButton = queryByTestId(/randomizer-approveButton/i)
+  expect(resultApproveButton).toBeInTheDocument()
+})
+
+test('pressing the result approval button calls the restaurant service to increase selectedAmount', async () => {
+  const { queryByTestId } = await actRender(<Randomizer />)
+  await wait(() => fireEvent.click(queryByTestId(/randomizer-randomizeButton/i)))
+  await wait(() => fireEvent.click(queryByTestId(/randomizer-approveButton/i)))
+  expect(restaurantService.increaseSelectedAmount).toHaveBeenCalled()
+})
+
+test('pressing the result approval button hides itself, the re-roll button and the filter', async () => {
+  const { queryByTestId } = await actRender(<Randomizer />)
+  await wait(() => fireEvent.click(queryByTestId(/randomizer-randomizeButton/i)))
+  await wait(() => fireEvent.click(queryByTestId(/randomizer-approveButton/i)))
+  expect(queryByTestId(/randomizer-randomizeButton/i)).not.toBeInTheDocument()
+  expect(queryByTestId(/randomizer-approveButton/i)).not.toBeInTheDocument()
+  expect(queryByTestId(/filter-container/i)).not.toBeInTheDocument()
 })
 
 test('pressing the button changes the text', async () => {

--- a/packages/app/src/components/RestaurantEntry/RestaurantEntry.js
+++ b/packages/app/src/components/RestaurantEntry/RestaurantEntry.js
@@ -51,14 +51,18 @@ const RestaurantEntry = ({ restaurant, showMap }) => {
           showMap && <Comments placeId={placeId} />
         }
       </div>
-      {restaurant !== undefined && restaurant.notSelectedAmount > 0 && <OverlayTrigger
+      {restaurant !== undefined && restaurant.resultAmount > 0 && <OverlayTrigger
         placement='right'
         overlay={
           <Tooltip >
-            {restaurant.name + ' has won the lottery ' + restaurant.resultAmount + ' times. ' + restaurant.name + ' was not chosen ' + restaurant.notSelectedAmount + ' times.'}
+            {restaurant.name + ' has won the lottery ' + restaurant.resultAmount + ' times. ' 
+            + 'It was selected ' + restaurant.selectedAmount + ' times. '
+            + '(Re-rolled ' + restaurant.notSelectedAmount + ' times)'}
           </Tooltip>
         } >
-        <p className='randomizer-resultApproval'>Lunch Lottery users approved this restaurant {Math.round((restaurant.resultAmount - restaurant.notSelectedAmount) / restaurant.resultAmount * 100)}% of the time</p>
+        <p className='randomizer-resultApproval'>
+          Lunch Lottery users picked this restaurant {Math.round((restaurant.selectedAmount / restaurant.resultAmount * 100))}% of the time
+        </p>
       </OverlayTrigger>
       }
     </div>

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -1,7 +1,6 @@
 /* GENERAL */
 
 @import url('https://fonts.googleapis.com/css?family=Galada&display=swap');
-@import url('https://fonts.googleapis.com/css?family=Permanent+Marker&display=swap');
 
 h1 {
   font-family: 'Galada';

--- a/packages/app/src/services/restaurant.js
+++ b/packages/app/src/services/restaurant.js
@@ -38,6 +38,11 @@ const increaseResultAmount = async (id) => {
   return response.data
 }
 
+const increaseSelectedAmount = async (id) => {
+  const response = await axios.put(`${baseUrl}/increaseSelected/${id}`)
+  return response.data
+}
+
 const increaseNotSelectedAmount = async (id) => {
   const response = await axios.put(`${baseUrl}/increaseNotSelected/${id}`)
   return response.data
@@ -50,7 +55,7 @@ export default {
   remove,
   getAllMatches,
   update,
+  increaseSelectedAmount,
   increaseNotSelectedAmount,
   increaseResultAmount
-
 }

--- a/packages/backend/src/controllers/restaurants.js
+++ b/packages/backend/src/controllers/restaurants.js
@@ -183,6 +183,18 @@ restaurantsRouter.put('/increaseResult/:id', async (request, response, next) => 
   }
 })
 
+// increase the amount of times the restaurant has been picked by an user
+restaurantsRouter.put('/increaseSelected/:id', async (request, response, next) => {
+  try {
+    const restaurant = await Restaurant.findById(request.params.id)
+    restaurant.selectedAmount = restaurant.selectedAmount + 1
+    await Restaurant.findByIdAndUpdate(restaurant.id, restaurant)
+    return response.status(200).end()
+  } catch (error) {
+    next(error)
+  }
+})
+
 // increase notSelectedAmount
 restaurantsRouter.put('/increaseNotSelected/:id', async (request, response, next) => {
   try {

--- a/packages/backend/src/controllers/restaurants.test.js
+++ b/packages/backend/src/controllers/restaurants.test.js
@@ -150,8 +150,18 @@ test('put request to increaseResult increases resultAmount', async () => {
     .put(`/api/restaurants/increaseResult/${testRestaurantId}`)
   const resAfter = await Restaurant.findById(testRestaurantId)
   expect(resAfter.resultAmount).toBe(resultAmount + 1)
-
 })
+
+test('put request to increaseSelected increases the selectedAmount attribute by one', async () => {
+  const testRestaurantId = restaurants[0].id
+  const testRestaurant = await Restaurant.findById(testRestaurantId)
+
+  await server.put(`/api/restaurants/increaseSelected/${testRestaurantId}`)
+  
+  const updatedRestaurant = await Restaurant.findById(testRestaurantId)
+  expect(updatedRestaurant.selectedAmount).toBe(testRestaurant.selectedAmount + 1)
+})
+
 test('put request to increaseNotSelected increases notSelected', async () => {
   const testRestaurantId = restaurants[0].id
   const res = await Restaurant.findById(testRestaurantId)
@@ -161,7 +171,6 @@ test('put request to increaseNotSelected increases notSelected', async () => {
     .put(`/api/restaurants/increaseNotSelected/${testRestaurantId}`)
   const resAfter = await Restaurant.findById(testRestaurantId)
   expect(resAfter.notSelectedAmount).toBe(notSelectedAmount + 1)
-
 })
 
 test('getAllMatches request without category ids or distance returns all restaurants', async () => {
@@ -464,6 +473,7 @@ describe('when logged in', () => {
       categories: [],
       address: 'Senaatintori',
       coordinates: { latitude: 60, longitude: 24 },
+      selectedAmount: 0,
       notSelectedAmount: 0,
       resultAmount: 0,
       distance: 1000,

--- a/packages/backend/src/models/restaurant.js
+++ b/packages/backend/src/models/restaurant.js
@@ -10,16 +10,6 @@ const restaurantSchema = new mongoose.Schema({
     minlength: 3,
     maxlength: 240
   },
-  notSelectedAmount: {
-    type: Number,
-    required: true,
-    default: 0
-  },
-  resultAmount: {
-    type: Number,
-    required: true,
-    default: 0
-  },
   url: {
     type: String,
     required: false,
@@ -56,6 +46,21 @@ const restaurantSchema = new mongoose.Schema({
     type: String,
     required: features.googleApi,
   },
+  selectedAmount: {
+    type: Number,
+    required: true,
+    default: 0
+  },
+  notSelectedAmount: {
+    type: Number,
+    required: true,
+    default: 0
+  },
+  resultAmount: {
+    type: Number,
+    required: true,
+    default: 0
+  }
 })
 
 restaurantSchema.set('toJSON', {


### PR DESCRIPTION
- When the lottery has been performed, two buttons are now shown
  - An approval button to lock this restaurant as the final result - as in, the user has decided that they are going to this restaurant
  - A disapproval button that functions as a re-roll button exactly like it used to.
- Clicking the approval button... 
  - ...calls a new API endpoint for restaurants that increases the value of `selectedAmount`, an attribute similar to ´notSelectedAmount´ representing the number of times users selected decided to go to this restaurant
  - ...hides the option to roll another restaurant. This is where you'll be going now!