### PR TITLE
Csswip

### DIFF
--- a/packages/app/src/App.css
+++ b/packages/app/src/App.css
@@ -6,15 +6,38 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    flex-direction: column;
     min-height: 90vh;
 }
 
 .main-footer {
-    padding: 0.5em;
     position: fixed;
-    bottom: 0;
+    bottom: 0.5em;
+    left: 0;
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
 }
 
 .main-footer > a {
-    margin-right: 1em;
+    margin: 0 1em;
+}
+
+@media screen and (max-width: 990px) {
+    .main-footer {
+        display: none
+    }
+    .phone-only {
+        display: block;
+    }
+    .phone-only > a {
+        color: rgba(0,0,0,0.5)
+    }
+}
+
+@media screen and (min-width: 990px) {
+
+    .phone-only {
+        display: none
+    }
 }

--- a/packages/app/src/App.js
+++ b/packages/app/src/App.js
@@ -72,9 +72,10 @@ const App = () => {
         </Switch>
       </section>
       <footer className='main-footer'>
-        <Link to='/attributions'>About</Link>
-        <a href={feedbackUrl}> Give Feedback </a>
+        <Link to='/attributions' className="">About</Link>
+        <a href={feedbackUrl} className=""> Give Feedback </a>
       </footer>
+
     </>
   )
 }

--- a/packages/app/src/components/Comments/Comments.css
+++ b/packages/app/src/components/Comments/Comments.css
@@ -1,31 +1,33 @@
-@media only screen and (min-width: 1100px) {
-
-  .review-component {
+.review-component {
     display: flex;
     flex-direction: column;
     font-size: 11px;
-    height: 400px;
-    width: 360px;
-    right: 1em;
+    max-width: 92vw;
+    width: 420px;
+    margin: 0 1em;
+    padding-top: 0em;
+}
+
+@media only screen and (min-width: 925px) {
+  .review-component {
     overflow-y: auto;
-    margin-left: 1em;
-    padding: 1em;
+    height: 420px;
   }
 }
 
-@media only screen and (max-width: 1100px) {
-
-    .review-component {
-        font-size: 11px;
-        width: 360px;
-        max-width: 100vw;
-        margin-bottom: 2em;
-    }
-    
+@media only screen and (max-width: 960px) {
+  .review-component {
+    margin: auto;
+    margin-top: 1em;
   }
+}
 
 .review-component > p {
   border-radius: 1em;
   background-color: rgba(0, 0, 0, 0.4);
   padding: 1em;
+}
+
+.review-component > h5 {
+  text-align: center;
 }

--- a/packages/app/src/components/Filter/Filter/Filter.css
+++ b/packages/app/src/components/Filter/Filter/Filter.css
@@ -1,8 +1,6 @@
 .input-group-text {
     background-color: rgba(0, 0, 0, 0) !important;
     color:white;
-    text-decoration-line: underline;
-    text-decoration-style: wavy;
     text-decoration-color: rgba(255, 255, 255, 0.5);
     border: none;
     margin-left: 4px;
@@ -17,6 +15,8 @@
     flex-direction:column;
     align-items: flex-start;
     justify-content: flex-start;
+    width: 480px;
+    max-width:100vw;
 }
 @media only screen and (min-width: 600px) {
     .category-filter {
@@ -44,6 +44,7 @@
     flex-direction: row;
     align-items: flex-start;
     flex-wrap: wrap;
+    width:100%;
 }
 .distance-filter {
     display: flex;
@@ -74,12 +75,16 @@
     justify-content: space-evenly;
 }
 
-.filter-typeselect > .input-group > .input-group-prepend > .input-group-text {
-    flex: 1;
-}
+
+@media only screen and (max-width: 600px) {
+    .filter-typeselect > .input-group > .input-group-prepend > .input-group-text {
+        flex: 1;
+    }
+  }
 
 .input-group-text {
     background-color: rgba(255, 255, 255, 0.85);
+    margin: 0;
 }
 
 .filter-typeselect > .input-group > .input-group-prepend > .dropdown {
@@ -91,4 +96,9 @@
     display:flex;
     align-items: center;
     justify-content:center;
+}
+
+.dropdown-menu.show {
+    right: 20px !important;
+    left: -10px !important;
 }

--- a/packages/app/src/components/NavBar.js
+++ b/packages/app/src/components/NavBar.js
@@ -15,6 +15,8 @@ const NavBar = ({ loggedIn }) => {
     history.push('/')
   }
 
+  const feedbackUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSfJ5xgfitDjlvHMmcasz2atmjEu1UGwKmWdgWowcpRja0xn_g/viewform'
+
   return (
     <Navbar collapseOnSelect bg="light" expand="lg">
       <Navbar.Brand as={Link} href='#' to='/'>Lunch Application</Navbar.Brand>
@@ -33,6 +35,12 @@ const NavBar = ({ loggedIn }) => {
               : 'Suggest Editing Restaurants'
             }
           </Nav.Link>
+          <Nav.Link as={Link} href='#' to='/attributions' className="phone-only">
+            About
+          </Nav.Link>
+          <Nav.Item href='#' className="phone-only">
+            <a href={feedbackUrl}>Give Feedback</a>
+          </Nav.Item>
         </Nav>
         <Nav className="ml-auto">
           {loggedIn &&
@@ -49,13 +57,13 @@ const NavBar = ({ loggedIn }) => {
             </>
           }
         </Nav>
+        <Nav className="ml-auto">
+          {loggedIn
+            ? <Button data-testid='logout-button' onClick={logout} variant="danger" className="mr-auto">Logout</Button>
+            : <Button data-testid='admin-button' onClick={() => history.push('/login')} variant='light' size='sm' className='mr-auto'>Admin Login</Button>
+          }
+        </Nav>
       </Navbar.Collapse>
-      <Nav className="ml-auto">
-        {loggedIn
-          ? <Button data-testid='logout-button' onClick={logout} variant="danger" className="ml-auto">Logout</Button>
-          : <Button data-testid='admin-button' onClick={() => history.push('/login')} variant='light' size='sm' className='ml-auto'>Admin Login</Button>
-        }
-      </Nav>
     </Navbar>
   )
 }

--- a/packages/app/src/components/Photos/PhotoCarousel.css
+++ b/packages/app/src/components/Photos/PhotoCarousel.css
@@ -1,39 +1,35 @@
-.photo-component {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    width: 360px;
-    height: 360px;
-    margin: auto; 
-}
-
 .carousel {
-    height: 360px;
+    width:420px;
+    height: 420px;
     max-width: 100vw;
+    max-height: 100vw;
     margin:auto;
     object-fit: contain;
     background: rgba(0,0,0,0.5);
 }
 
 .carousel-inner {
-    width: 360px;
-    height: 360px;
+    width: 420px;
+    height: 420px;
+    max-width: 100vw;
+    max-height: 100vw;
     margin:auto;
     object-fit: contain;
 }
 .carousel-caption {
     background: rgba(0,0,0,0.5);
     bottom: 0 !important;
+    left: 0 !important;
+    right: 0 !important;
     padding-bottom: 0 !important;
     padding-top: 0.5em !important;
 }
 
 .d-block {
-    height: 360px;
-    max-height: 90vw;
-    max-width: 90vw;
-    width: 360px;
+    width: 420px;
+    height: 420px;
+    max-width: 100vw;
+    max-height: 100vw;
     margin:auto;
     object-fit: contain;
 }

--- a/packages/app/src/components/Photos/PhotoCarousel.js
+++ b/packages/app/src/components/Photos/PhotoCarousel.js
@@ -2,12 +2,12 @@ import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { Carousel } from 'react-bootstrap'
 import photoService from '../../services/photo'
- 
+
 import './PhotoCarousel.css'
- 
+
 const PhotoCarousel = ({ placeId }) => {
   const [restaurantPhotos, setRestaurantPhotos] = useState()
- 
+
   useEffect(() => {
     const getPhotos = async () => {
       if (placeId !== undefined) {
@@ -17,10 +17,10 @@ const PhotoCarousel = ({ placeId }) => {
     }
     getPhotos()
   }, [placeId])
- 
+
   return (
-    <div className='photo-component'>
-      {restaurantPhotos &&
+    <>
+      {restaurantPhotos ?
         <Carousel
           indicators={false}
           slide='true'
@@ -29,19 +29,22 @@ const PhotoCarousel = ({ placeId }) => {
           {restaurantPhotos.map(photo => {
             return (
               <Carousel.Item key={photo.url} className='photo'>
-                <img  className="d-block w-100" src={photo.url} alt='The restaurant' />
+                <a href={photo.url}>
+                  <img className="d-block w-100" src={photo.url} alt='The restaurant' />
+                </a>
                 <Carousel.Caption dangerouslySetInnerHTML={{ __html: photo.html_attributions }} />
               </Carousel.Item>
             )
           })}
         </Carousel>
+        : <div className="carousel-inner" />
       }
-    </div >
+    </>
   )
 }
- 
+
 PhotoCarousel.propTypes = {
   placeId: PropTypes.string
 }
- 
+
 export default PhotoCarousel

--- a/packages/app/src/components/Randomizer/Randomizer.css
+++ b/packages/app/src/components/Randomizer/Randomizer.css
@@ -1,15 +1,16 @@
 .randomizer {
-    height: 100%;
+    width: 100%;
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
     border-radius: 1em;
+    min-height: inherit;
 }
 
 .randomizer > h1 {
-    margin-top: 0.5em;
     text-align: center;
+    margin-top: 1em;
 }
 
 .randomizer-showFilterButton {
@@ -21,5 +22,37 @@
 }
 
 .randomizer-approveButton {
+    margin-top: 1em;
     margin-bottom: 0.5em;
+}
+
+.roll-label {
+    position: fixed;
+    top: 10vw;
+}
+
+@media only screen and (max-width: 600px) {
+  .roll-label {
+     right: 0;
+     left: 0;
+  }
+}
+
+@media only screen and (max-height: 700px) and (max-width: 600px){
+    .roll-label {
+       min-height: 17.5%
+    }
+  }
+
+@media only screen and (min-height: 700px) and (max-width: 600px) {
+    .roll-label {
+       min-height: 15%
+    }
+  }
+  
+
+@media only screen and (min-width: 600px) {
+    .roll-label {
+       min-width: 480px;
+    }
 }

--- a/packages/app/src/components/Randomizer/Randomizer.js
+++ b/packages/app/src/components/Randomizer/Randomizer.js
@@ -127,7 +127,7 @@ const Randomizer = ({
     const hasRestaurant = !!restaurant
     return hasRestaurant
       ? isRolling
-        ? <h1 data-testid='roll-label'>{restaurant.name}</h1>
+        ? <h1 data-testid='roll-label' className="roll-label">{restaurant.name}</h1>
         : <>
           <Confetti />
           {resultSelected && <h1>No backing down now! You&apos;re having lunch at:</h1>}
@@ -144,7 +144,7 @@ const Randomizer = ({
               </span>
             </Button>}
         </>
-      : <h1 data-testid='randomizer-resultLabel'>Hungry? Press the button!</h1>
+      : <h1 data-testid='randomizer-resultLabel' className='roll-label'>Hungry? Press the button!</h1>
   }
 
   const rollsRemaining = maxNumberOfRolls - iteration

--- a/packages/app/src/components/RestaurantEntry/RestaurantEntry.css
+++ b/packages/app/src/components/RestaurantEntry/RestaurantEntry.css
@@ -8,9 +8,9 @@
     padding-left: 3em;
     padding-right: 3em;
     padding-top: 2em;
-    margin-bottom: 1em;
     background-color: rgba(0, 0, 0, 0.5);
     border-radius: 1em; 
+    margin-top: 1em;
   }
 }
 
@@ -23,6 +23,7 @@
     align-items: center;
     padding-top: 2em;
     margin-bottom: 1em;
+    margin-top: 1em;
     background-color: rgba(0, 0, 0, 0.5);
     border-radius: 1em; 
   }
@@ -36,6 +37,7 @@
 
 .randomizer-resultContent > h1 {
     background: none;
+    text-align:center;
 }
 
 .randomizer-resultContent > .randomizer-resultContent-main {
@@ -57,4 +59,9 @@
 .restaurantentry-showmap-button:hover {
   text-decoration: underline;
   color:rgba(255,255,255,1); 
+}
+
+.randomizer-resultApproval {
+  margin: 1em;
+  text-align: center;
 }

--- a/packages/app/src/components/Restaurants/form/RestaurantForm.css
+++ b/packages/app/src/components/Restaurants/form/RestaurantForm.css
@@ -31,14 +31,25 @@
     display:flex;
     flex-direction: row;
 }
+
+.address-field > .form-control {
+    width: 80%;
+}
+
+.address-field > button {
+    width: 20%;
+}
+
 .restaurant-form {
     background: rgba(0,0,0,0.5);
     padding: 2em;
     border-radius: 1em;
-    min-width:320px;
+    width:640px;
+    max-width: 90vw;
+    margin-top: 5vh;
 }
 
 .add-form > .map > .leaflet-container {
-    width: 420px;
+    width: 100%;
     height: 420px;
 }

--- a/packages/app/src/components/auth/LoginForm.css
+++ b/packages/app/src/components/auth/LoginForm.css
@@ -1,0 +1,5 @@
+.loginform {
+    background:rgba(0,0,0,0.5);
+    padding: 2em;
+    border-radius: 1em;
+}

--- a/packages/app/src/components/auth/LoginForm.js
+++ b/packages/app/src/components/auth/LoginForm.js
@@ -3,6 +3,8 @@ import { Form, Button, Alert } from 'react-bootstrap'
 import { useHistory } from 'react-router-dom'
 import authService from '../../services/authentication'
 
+import './LoginForm.css'
+
 const LoginForm = () => {
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
@@ -23,7 +25,7 @@ const LoginForm = () => {
 
   return (
     <>
-      <Form onSubmit={handleLogin}>
+      <Form className="loginform" onSubmit={handleLogin}>
         <Form.Group data-testid='loginform-usernameField'>
           <Form.Label >Username</Form.Label>
           <Form.Control

--- a/packages/app/src/components/p5Components/FoodModel/FoodModel.css
+++ b/packages/app/src/components/p5Components/FoodModel/FoodModel.css
@@ -1,10 +1,16 @@
 .foodmodel-canvas {
-    max-width: 400px;
-    max-height: 400px;
+    width: 400px;
+    height: 400px;
+    max-width: 85vw;
+    max-height: 85vw;
 }
 
 .foodmodel-canvas > * > .p5Canvas {
     pointer-events: none;
     width: 100% !important;
     height: 100% !important;
+}
+
+.foodmodel {
+    margin-top: auto;
 }

--- a/packages/app/src/components/suggestionlist/SuggestionList.css
+++ b/packages/app/src/components/suggestionlist/SuggestionList.css
@@ -6,6 +6,7 @@
 .suggestionList-title {
     text-align: center;
     margin-bottom: 0.5em;
+    margin-top: 1em;
 }
 
 .suggestion-entry > .buttons > button {
@@ -22,4 +23,17 @@
 
 .suggestion-entry > .card-header.EDIT {
     background-color: #faa629;
+}
+
+.suggestionlist {
+    max-width: 100vw
+}
+
+.table-responsive-sm {
+    overflow-x: auto;
+    margin: auto;
+}
+
+.text-centered {
+    text-align:center;
 }

--- a/packages/app/src/components/suggestionlist/SuggestionList.js
+++ b/packages/app/src/components/suggestionlist/SuggestionList.js
@@ -27,7 +27,7 @@ export const SuggestionList = () => {
   }
 
   return (
-    <div data-testid='suggestionList'>
+    <div data-testid='suggestionList' className="suggestionlist">
       <h1 data-testid='suggestionList-title' className='suggestionList-title'>Pending Suggestions</h1>
       <List
         entries={suggestions}
@@ -87,7 +87,7 @@ export const SuggestionEntry = ({ suggestion, handleApprove, handleReject }) => 
       {restaurant &&
         <>
           <Card.Body>
-            <Card.Title data-testid='suggestionEntry-restaurantName'>{restaurant && restaurant.name}</Card.Title>
+            <Card.Title data-testid='suggestionEntry-restaurantName' className="text-centered">{restaurant && restaurant.name}</Card.Title>
           </Card.Body>
           <Card.Body>
             <Table striped bordered responsive='sm' size='sm'>

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -25,19 +25,21 @@ code {
 }
 
 a {
-  color: rgba(255, 255, 255, 0.7);
+  color: rgba(255, 255, 255, 0.95);
 }
 
 a:hover {
-  color: rgba(255, 255, 255, 0.9);
+  color: rgba(255, 255, 255, 1);
 }
 
 #root {
   min-height: 100vh;
   height: 100%;
-  background: url('https://images.pexels.com/photos/347139/pexels-photo-347139.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1260');
+  background: url('https://images.pexels.com/photos/347139/pexels-photo-347139.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=1080&w=1980');
   background-position: bottom;
   background-attachment: fixed;
+  background-size: cover;
+  background-repeat: no-repeat;
   color: white;
 }
 

--- a/packages/app/src/services/photo.js
+++ b/packages/app/src/services/photo.js
@@ -1,8 +1,14 @@
 import axios from 'axios'
+
+import testData from '../util/testData'
 const baseUrl = '/api/places/details/photos'
 
+const testing = false
+
 const getAllPhotosForRestaurant = async (placeId) => {
-  const response = await axios.get(`${baseUrl}/${placeId}`)
+  const response = testing
+    ? testData.getAllPhotosForRestaurant()
+    :  await axios.get(`${baseUrl}/${placeId}`)
   return response.data
 }
 

--- a/packages/app/src/util/testData.js
+++ b/packages/app/src/util/testData.js
@@ -99,5 +99,37 @@ const getRestaurant = () => {
   )
 }
 
+const getAllPhotosForRestaurant = () => {
+  return (
+    {
+      data:
+        [
+          {
+            height: 3024,
+            html_attributions: ['<a href="https://maps.google.com/maps/contrib/113964038534896168778">Erkki Jaanhold</a>'],
+            photo_reference: 'CmRaAAAA29_TXMoH-PwzuuAcpPtvgRriecF7RpXprnx_ORgN3rvcyjqOQap3_krTPxfKWp5kF5abZncBJ8B812lmL7IESS0y2iubJ97dCtEUyzvUMlv_rBP9T2xQHWbJkACm2z1NEhAEb-kAX-epiD-8iV_dMJ7rGhQIg40u9D3IJS6r_-xIkvWH4KXNSg',
+            width: 4032,
+            url: 'https://lh3.googleusercontent.com/p/AF1QipPdQMvRBPNWwb44WZU47-mYPXumAKnZnRfqULZB'
+          },
+          {
+            height: 2268,
+            html_attributions: ['<a href="https://maps.google.com/maps/contrib/115272919380677058282">Henry Kong</a>'],
+            photo_reference: 'CmRaAAAAsvjwa24ioURJ7q4B7A-PYI4I9-1hBd9nQbdv0zaHrjjOdbTi4sJYtkiHFT6MWLbr0GsztA9hrKyTw19QO4YiixuHz5v78f7aqrbwXOnxEqepqMMf1oO6nCFWihEEqexREhA3OqzLJA5gAaFT_DKbL2dgGhTfBcMlIFOm-5cGYKxBNvAAm4yHVA',
+            width: 4032,
+            url: 'https://lh3.googleusercontent.com/p/AF1QipMDwtactiGe8W7GCkSjCGl3RNC3WndG2EfZk2xK=s1600-w360-h360'
 
-export default { getSuggestions, getRestaurant }
+          },
+          {
+            height: 4032,
+            html_attributions: ['<a href="https://maps.google.com/maps/contrib/107797582338284257486">Jussi Lemmetyinen</a>'],
+            photo_reference: 'CmRaAAAAH_G9OhWtsVt5KlfNB1LN2HRdCDn_Ho722z2F1uHj8-LfYXXpoccrHcCbCtDYlePX4w1cqjU3Ii_kYxkvWvU3ha3CeQaSNdoqlqZ_i9ZbTY76NCfty54JWFrVaKyqiq_mEhCMswvGkAKJNNiXXiG-1usbGhSle1IUd2f1Jqh-M-0vy-UvIRvmcg',
+            width: 3024,
+            url: 'https://lh3.googleusercontent.com/p/AF1QipOX4iL9UHTrC2drfcixqIOrsT41joGUJa6B12Fp=s1600-w360-h360'
+          }
+        ]
+    }
+  )
+}
+
+
+export default { getSuggestions, getRestaurant, getAllPhotosForRestaurant }

--- a/packages/backend/src/services/google.js
+++ b/packages/backend/src/services/google.js
@@ -139,8 +139,8 @@ const getAllPhotos = async (placeId) => {
  * @param {string} reference The photo_reference attribute of the photo
  */
 const getUrl = async (reference) => {
-  const width = 360
-  const height = 360
+  const width = 420
+  const height = 420
   const result = await axios.get(`${baseUrl}/place/photo?maxwidth=${width}&maxheight=${height}&photoreference=${reference}&key=${API_KEY}`)
   const photoUrl = result.request._redirectable._options.href
   return photoUrl


### PR DESCRIPTION
- components do not stretch the screen horizontally anymore
- inputs do not stretch the component around them horizontally (text input, choosing categories)
- login/logout button is in the navbar dropdown
- roll-label for the restaurant names does not move the bowl up or down
- roll-label base size has been increased, so that it stretches less often (not at all with the current names, )
- a lot of stuff got centered with text align or margin-auto
- footer does not block the filter button on narrow screens
- background stretches to fit screen, so super high screens do not have whitespace anymore.
- comments are all rendered on screen, rather than with overflow, on narrow screens, to make scrolling the screen less clumsy
- photos and comment box are bigger and have less chance of being off-kilter or stretching the screen
- photos are now links to the photo source (although since it's limited to 420px, they're not getting a better version atm by clicking on it).
- testData file has been appended with a function that simulates a photo-request response from google. 
- footer disappears and the links are in the navbar dropdown when screen width < 990px (which is roughly the breakpoint for bootstrap's navbar collapse).