### PR TITLE
Add error messages related to failed autocompletion attempts

### DIFF
--- a/packages/app/src/components/Restaurants/form/RestaurantForm.css
+++ b/packages/app/src/components/Restaurants/form/RestaurantForm.css
@@ -37,7 +37,7 @@
 }
 
 .address-field > button {
-    width: 20%;
+    min-width: 20%;
 }
 
 .restaurant-form {

--- a/packages/app/src/components/Restaurants/form/RestaurantForm.js
+++ b/packages/app/src/components/Restaurants/form/RestaurantForm.js
@@ -45,6 +45,7 @@ const RestaurantForm = ({ restaurant, setRestaurant, onSubmit, submitMessage = '
     try {
       const fetched = await placeService.getSuggestions(name)
       setSuggestions(fetched)
+      setErrors({ ...errors, general: undefined })
     } catch (error) {
       error.response.status === 503
         ? setErrors({ ...errors, general: 'Fetching autocomplete suggestions failed. Contact your admin about a possibly reached Google API query limit.' })

--- a/packages/app/src/services/places.js
+++ b/packages/app/src/services/places.js
@@ -1,20 +1,13 @@
 import axios from 'axios'
-import testdata from '../util/testData'
 const baseUrl = '/api/places'
 
-const testing = false
-
 const getSuggestions = async (text) => {
-  const suggestions = testing
-    ? testdata.getSuggestions()
-    : await axios.get(`${baseUrl}/autocomplete/${text}`)
+  const suggestions = await axios.get(`${baseUrl}/autocomplete/${text}`)
   return suggestions.data
 }
 
 const getRestaurant = async (id) => {
-  const restaurant = testing
-    ? testdata.getRestaurant()
-    : await axios.get(`${baseUrl}/details/addform/${id}`)
+  const restaurant = await axios.get(`${baseUrl}/details/addform/${id}`)
   return restaurant.data.result
 }
 

--- a/packages/backend/src/services/google.js
+++ b/packages/backend/src/services/google.js
@@ -91,7 +91,7 @@ const findDetails = async (placeId, fields) => {
  */
 const autocomplete = async (text) => {
   const outputFormat = 'json'   // 'json' | 'xml'
-  const response = await axios.get(`${baseUrl}/place/autocomplete/${outputFormat}?input=${text}&types=establishment&strictbounds&origin=${LATITUDE},${LONGITUDE}&location=${LATITUDE},${LONGITUDE}&radius=${SEARCH_RADIUS}&key=${API_KEY}`)
+  const response = await axios.get(`${baseUrl}/place/autocomplete/${outputFormat}?input=${encodeURI(text)}&types=establishment&strictbounds&origin=${LATITUDE},${LONGITUDE}&location=${LATITUDE},${LONGITUDE}&radius=${SEARCH_RADIUS}&key=${API_KEY}`)
   switch (response.data.status) {
     case 'OK':
       return response.data.predictions


### PR DESCRIPTION
- Added user-friendly error messages to `RestaurantForm.js` for cases where calls to Google API fail.
  - Status `503` tells the user to contact an administrator about a reached query limit
  - Status `404` in case an autocompleted suggestion does not, for some reason, have details, tells the user that a restaurant might have been removed from the API.