### PR TITLE
Add new configuration variables

### DIFF
--- a/documentation/installation.md
+++ b/documentation/installation.md
@@ -64,6 +64,16 @@ For security reasons, there are no hard-coded defaults for security-critical con
 | PORT                 | no       | The port the server listens to. Defaults to `3001` |
 | SALT_ROUNDS          | no       | Number of `bcrypt` salt rounds. Default is `10`, but higher values are stongly encouraged for production use. Generally, higher value means more secure  passwords, but higher computational cost. |
 | NODE_ENV             | no       | Tells the app a bit about where it is running. *Should* always be set to `production` when running in production environment, but not strictly necessary. |
+| OFFICE_LAT           | no       | The latitude for the origin point that is used when calculating distances to restaurants. Defaults to `60.170000` if not set. *Please note that you may need to adjust the front-end variable as well (see below)* |
+| OFFICE_LON           | no       | The logitude for the origin point that is used when calculating distances to restaurants. Defaults to `24.941944` if not set. *Please note that you may need to adjust the front-end variable as well (see below)* |
+
+**Additionally**, there are some configuration variables available for the application's front-end. These can be set in `/packages/app/src/config.js`.
+
+| Configuration variable | Required | Used by              | Description |
+|------------------------|----------|----------------------|-------------|
+| appName                | no       | `packages/app/src/components/NavBar.js`, `packages/app/src/components/RestaurantEntry/RestaurantEntry.js` (Component), `packages/app/src/index.js` | The name of the application. Defaults to `Lunch Lottery`. Note that the document's title is only changed when the application is done loading. If you'd like to adjust the temporary loading title, go to `packages/app/public/index.html` |
+| officeLat              | no       | `location.js` (Service) | The latitude of the origin point that is used when fetching directions from the DigiTransit API. Defaults to `60.170000` if not set. *Please note that you may need to adjust the back-end variable as well (see above)* |
+| officeLon              | no       | `location.js` (Service) |The longitude of the origin point that is used when fetching directions from the DigiTransit API. Defaults to `24.941944` if not set. *Please note that you may need to adjust the back-end variable as well (see above)* |
 
 
 ### Google API Key

--- a/packages/app/src/components/NavBar.js
+++ b/packages/app/src/components/NavBar.js
@@ -3,6 +3,7 @@ import { Nav, Navbar, Button } from 'react-bootstrap'
 import { Link, useHistory } from 'react-router-dom'
 import PropTypes from 'prop-types'
 
+import { appName } from '../config'
 import authService from '../services/authentication'
 
 const NavBar = ({ loggedIn, changeLoginStatus }) => {
@@ -18,7 +19,7 @@ const NavBar = ({ loggedIn, changeLoginStatus }) => {
 
   return (
     <Navbar collapseOnSelect bg="light" expand="lg">
-      <Navbar.Brand as={Link} href='#' to='/'>Lunch Application</Navbar.Brand>
+      <Navbar.Brand as={Link} href='#' to='/'>{appName}</Navbar.Brand>
       <Navbar.Toggle aria-controls="basic-navbar-nav" />
       <Navbar.Collapse id="basic-navbar-nav">
         <Nav className="mr-auto">

--- a/packages/app/src/components/RestaurantEntry/RestaurantEntry.js
+++ b/packages/app/src/components/RestaurantEntry/RestaurantEntry.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { OverlayTrigger, Tooltip } from 'react-bootstrap'
 import { Link } from '@material-ui/icons'
 import PropTypes from 'prop-types'
+import { appName } from '../../config'
 import MapModal from '../MapModal/MapModal'
 import Comments from '../Comments/Comments'
 import PhotoCarousel from '../Photos/PhotoCarousel'
@@ -66,7 +67,7 @@ const RestaurantEntry = ({ restaurant }) => {
           </Tooltip>
         } >
         <p className='randomizer-resultApproval'>
-          Lunch Lottery users picked this restaurant {Math.round((restaurant.selectedAmount / restaurant.resultAmount * 100))}% of the time
+          {appName} users picked this restaurant {Math.round((restaurant.selectedAmount / restaurant.resultAmount * 100))}% of the time
         </p>
       </OverlayTrigger>
       }

--- a/packages/app/src/config.js
+++ b/packages/app/src/config.js
@@ -1,0 +1,9 @@
+export const appName = 'Lunch Lottery'
+export const officeLat = 60.170000
+export const officeLon = 24.941944
+
+export default {
+  appName,
+  officeLat,
+  officeLon
+}

--- a/packages/app/src/index.js
+++ b/packages/app/src/index.js
@@ -5,6 +5,10 @@ import App from './App'
 import restaurantService from './services/restaurant'
 import { BrowserRouter as Router } from 'react-router-dom'
 
+import { appName } from './config'
+
+document.title = appName
+
 ReactDOM.render(
   <Router>
     <App restaurantService={restaurantService} />

--- a/packages/app/src/services/location.js
+++ b/packages/app/src/services/location.js
@@ -1,8 +1,11 @@
 import axios from 'axios'
 import poly from '@mapbox/polyline'
 
-const unityLat = 60.170000
-const unityLon = 24.941944
+import { officeLat, officeLon } from '../config'
+
+const unityLat = officeLat
+const unityLon = officeLon
+
 const baseUrl = 'https://api.digitransit.fi'
 const maxDistance = 50
 

--- a/packages/backend/src/config.js
+++ b/packages/backend/src/config.js
@@ -23,8 +23,8 @@ const bcryptSaltRounds = process.env.NODE_ENV === 'test'
   ? 4
   : process.env.SALT_ROUNDS || 10
 
-const originLatitude = 60.170000
-const originLongitude = 24.941944
+const originLatitude = process.env.OFFICE_LAT || 60.170000
+const originLongitude = process.env.OFFICE_LON || 24.941944
 
 if (dbUrl === null || dbUrl === undefined) {
   throw new Error('Database URL is not defined! Environment variable MONGODB_URI was empty. Either define it manually or add it to your .env')


### PR DESCRIPTION
- New back-end environment variables: `
  - `OFFICE_LAT` - The latitude of the origin point used for distance-filtered API calls. Defaults to the latitude of Kaivokatu 2.
  - `OFFICE_LON` - The longitude of the origin point used for distance-filtered API calls. Defaults to the longitude of Kaivokatu 2.
- New front-end configuration variables (in `packages/app/src/config.js`)
  - `appName` - The name of the application. Please note that the document's title is adjusted only once the page has been loaded. To adjust the temporary loading title, edit `packages/app/public/index.html`. This issue could also be solved by using additional dependencies.
  - `officeLat` - The latitude of the origin point used to get directions from the DigiTransit API. Defaults to the latitude of Kaivokatu 2.
  - `officeLon` - The longitude of the origin point used to get directions from the DigiTransit API. Defaults to the longitude of Kaivokatu 2.
- The above documentation has also been added to `documentation/installation.md`
