### PR TITLE
photo and review preload

### DIFF
--- a/packages/app/src/components/Comments/Comments.js
+++ b/packages/app/src/components/Comments/Comments.js
@@ -6,7 +6,6 @@ import { FormatQuote } from '@material-ui/icons'
 
 const Comments = ({ placeId }) => {
   const [restaurantReviews, setReviews] = useState()
-  const [showReviews, setShowReviews] = useState()
 
   useEffect(() => {
     const getReviews = async () => {
@@ -14,27 +13,24 @@ const Comments = ({ placeId }) => {
         try {
           const reviews = await commentService.getCommentsForRestaurant(placeId)
           setReviews(reviews)
-          setShowReviews(reviews.rating !== undefined)
         } catch (error) {
-          setShowReviews(false)
+          console.log(error)
         }
-      } else {
-        setShowReviews(false)
       }
-    } 
+    }
     getReviews()
   }, [placeId])
 
   return (
     <div data-testid='review-component' className='review-component'>
-      {showReviews &&
-      <>
-        <h5 className='review-rating'>Average rating on Google: {restaurantReviews.rating}</h5>
-        {restaurantReviews.reviews.map(rev => 
-          <p key={rev.text}><FormatQuote />{rev.text} &mdash;&nbsp;{rev.author_name}</p>)}
-      </>
+      {(restaurantReviews && restaurantReviews.reviews && restaurantReviews.rating)
+        ? <>
+          <h5 className='review-rating'>Average rating on Google: {restaurantReviews.rating}</h5>
+          {restaurantReviews.reviews.map(rev =>
+            <p key={rev.text}><FormatQuote />{rev.text} &mdash;&nbsp;{rev.author_name}</p>)}
+        </>
+        : <h5 data-testid='no-reviews'>No reviews yet...</h5>
       }
-      {!showReviews && <h5 data-testid='no-reviews'>No reviews yet...</h5>}
     </div>
   )
 }

--- a/packages/app/src/components/Filter/CategoryDropdown/CategoryDropdown.js
+++ b/packages/app/src/components/Filter/CategoryDropdown/CategoryDropdown.js
@@ -20,7 +20,6 @@ const CategoryDropdown = ({ text, selected, onAdd, onRemove }) => {
       show={dropdownOpen}
       onSelect={(eventKey) => {
         const clicked = categories.find(c => `${c.id}` === `${eventKey}`)
-
         if (isActive(clicked)) {
           onRemove(clicked.id)
         } else {

--- a/packages/app/src/components/Randomizer/Randomizer.js
+++ b/packages/app/src/components/Randomizer/Randomizer.js
@@ -217,7 +217,6 @@ const RandomizerButton = ({
     try {
       await onClick()
     } catch (errorResponse) {
-      console.log(errorResponse)
       errorResponse.response
         ? setError(errorResponse.response.data.error)
         : setError(errorResponse)

--- a/packages/app/src/components/Randomizer/Randomizer.js
+++ b/packages/app/src/components/Randomizer/Randomizer.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 import { Button } from 'react-bootstrap'
 import { ExpandMore, ExpandLess, ThumbUpAlt, ThumbDownAlt } from '@material-ui/icons'
@@ -26,8 +26,10 @@ const Randomizer = ({
   maxTimeBetweenRolls = 1000,
   resultWaitTime = 1250
 }) => {
-  let resId = null
   const [restaurant, setRestaurant] = useState()
+  const selectedRestaurant = useRef()
+  const rollsRemaining = useRef()
+  const shouldLoad = useRef()
   const [iteration, setIteration] = useState(maxNumberOfRolls)
   const [isRolling, setRolling] = useState(false)
   const [resultSelected, setResultSelected] = useState(false)
@@ -62,7 +64,6 @@ const Randomizer = ({
     }
   }
 
-
   const calculateTimeForNthRoll = (n) => {
     const t = n / maxNumberOfRolls
     const time = easingFunc(maxTimeBetweenRolls, minTimeBetweenRolls, t)
@@ -73,47 +74,54 @@ const Randomizer = ({
   }
 
   const handleApproveResult = async () => {
-    if (restaurant && restaurant.id) {
-      await restaurantService.increaseSelectedAmount(restaurant.id)
-      setRestaurant({ ...restaurant, selectedAmount: restaurant.selectedAmount + 1 })
-      setResultSelected(true)
+    if (selectedRestaurant.current && selectedRestaurant.current.id) {
+      selectedRestaurant.current = ({ ...selectedRestaurant.current, selectedAmount: selectedRestaurant.current.selectedAmount + 1 })
+      restaurantService.increaseSelectedAmount(selectedRestaurant.current.id)
     }
+    setResultSelected(true)
   }
 
   const startRolling = async () => {
-    filter.visible && setFilter({ ...filter, visible: false })
-    if (restaurant && restaurant.id) {
-      await restaurantService.increaseNotSelectedAmount(restaurant.id)
+    shouldLoad.current = false
+    rollsRemaining.current = maxNumberOfRolls
+    if (selectedRestaurant.current && selectedRestaurant.current.id) {
+      await restaurantService.increaseNotSelectedAmount(selectedRestaurant.current.id)
     }
-    const restaurants = await restaurantService.getAllMatches(filter.type, filter.categories, filter.distance)
+    let restaurants = await restaurantService.getAllMatches(filter.type, filter.categories, filter.distance)
+    restaurants = shuffle(restaurants)
+    selectedRestaurant.current = restaurants[maxNumberOfRolls % restaurants.length]
 
     if (restaurants.length === 1) {
-      setRestaurant(restaurants[0])
-      resId = restaurants[0].id
+      shouldLoad.current = true
+      setRestaurant(selectedRestaurant.current)
       soundService.playFanfare()
-      await restaurantService.increaseResultAmount(resId)
+      await restaurantService.increaseResultAmount(selectedRestaurant.current.id)
     } else {
       setRolling(true)
-      rollAfterTimeout(0, maxTimeBetweenRolls, shuffle(restaurants))
+      filter.visible && setFilter({ ...filter, visible: false })
+      rollAfterTimeout(0, maxTimeBetweenRolls, restaurants)
     }
   }
 
+
   const rollNext = async (roll, restaurants) => {
     setRestaurant(restaurants[roll % restaurants.length])
-    resId = restaurants[roll % restaurants.length].id
-    const rollsRemaining = maxNumberOfRolls - roll
+    rollsRemaining.current = maxNumberOfRolls - roll
 
-    const easterEggDidTrigger = nope.updateAndTryTrigger(restaurants, rollsRemaining)
+    const easterEggDidTrigger = nope.updateAndTryTrigger(restaurants, rollsRemaining.current)
     if (easterEggDidTrigger) {
       return
     }
 
     setIteration(roll)
-    if (rollsRemaining === 0) {
+    if (rollsRemaining.current < 5) {
+      shouldLoad.current = true
+    }
+    if (rollsRemaining.current === 0) {
       soundService.playFanfare()
       setTimeoutHandle(undefined)
       setRolling(false)
-      await restaurantService.increaseResultAmount(resId)
+      await restaurantService.increaseResultAmount(selectedRestaurant.current.id)
     } else {
       const timeout = calculateTimeForNthRoll(roll)
       rollAfterTimeout(roll + 1, timeout, restaurants)
@@ -126,25 +134,24 @@ const Randomizer = ({
     }
 
     const hasRestaurant = !!restaurant
-    return hasRestaurant
-      ? isRolling
-        ? <h1 data-testid='roll-label' className="roll-label">{restaurant.name}</h1>
-        : <>
-          <Confetti />
-          {resultSelected && <h1>No backing down now! You&apos;re having lunch at:</h1>}
-          <RestaurantEntry restaurant={restaurant} />
-        </>
+    return hasRestaurant ?
+      <>
+        {isRolling && <h1 data-testid='roll-label' className="roll-label">{restaurant.name}</h1>}
+        {!isRolling && <Confetti />}
+        {resultSelected && <h1>No backing down now! You&apos;re having lunch at:</h1>}
+        {shouldLoad.current && <RestaurantEntry hidden={isRolling} restaurant={selectedRestaurant.current} />}
+      </>
       : <h1 data-testid='randomizer-resultLabel' className='roll-label'>Hungry? Press the button!</h1>
   }
 
-  const rollsRemaining = maxNumberOfRolls - iteration
+  rollsRemaining.current = maxNumberOfRolls - iteration
   const isPicky = filter.categories.length > 0
   return (
     <div data-testid='randomizer' className='randomizer'>
       {nope.active && <h1>NOPE</h1>}
 
       <div data-testid='foodmodel-container' className='foodmodel' style={{ display: `${(restaurant && !isRolling) ? 'none' : 'inline'}` }}>
-        <FoodModel rolling={isRolling} rollsRemaining={rollsRemaining} />
+        <FoodModel rolling={isRolling} rollsRemaining={rollsRemaining.current} />
       </div>
       {!resultSelected &&
         <div className="randomizer-button-group">
@@ -155,7 +162,7 @@ const Randomizer = ({
             isRolling={isRolling}
             hasResult={restaurant !== undefined && !isRolling}
             maxNumberOfRolls={maxNumberOfRolls}
-            rollsRemaining={rollsRemaining}
+            rollsRemaining={rollsRemaining.current}
           />
           {(!isRolling && !!restaurant) &&
             <Button
@@ -210,7 +217,11 @@ const RandomizerButton = ({
     try {
       await onClick()
     } catch (errorResponse) {
-      setError(errorResponse.response.data.error)
+      console.log(errorResponse)
+      errorResponse.response
+        ? setError(errorResponse.response.data.error)
+        : setError(errorResponse)
+
       soundService.playTrombone()
     }
   }

--- a/packages/app/src/components/Randomizer/Randomizer.js
+++ b/packages/app/src/components/Randomizer/Randomizer.js
@@ -94,6 +94,7 @@ const Randomizer = ({
     if (restaurants.length === 1) {
       shouldLoad.current = true
       setRestaurant(selectedRestaurant.current)
+      filter.visible && setFilter({ ...filter, visible: false })
       soundService.playFanfare()
       await restaurantService.increaseResultAmount(selectedRestaurant.current.id)
     } else {

--- a/packages/app/src/components/RestaurantEntry/RestaurantEntry.js
+++ b/packages/app/src/components/RestaurantEntry/RestaurantEntry.js
@@ -9,7 +9,7 @@ import PhotoCarousel from '../Photos/PhotoCarousel'
 
 import '../RestaurantEntry/RestaurantEntry.css'
 
-const RestaurantEntry = ({ restaurant }) => {
+const RestaurantEntry = ({ restaurant, hidden }) => {
 
   const [showMap, setShowMap] = useState(false)
 
@@ -28,7 +28,7 @@ const RestaurantEntry = ({ restaurant }) => {
   const placeId = restaurant.placeId
 
   return (
-    <div className='randomizer-resultContent'>
+    <div className='randomizer-resultContent' style={{display: (hidden ? 'none' : 'flex')}}>
       <h1 data-testid='randomizer-resultLabel'>{restaurant.name}</h1>
       <p>
         {restaurant.url &&
@@ -80,7 +80,8 @@ const RestaurantEntry = ({ restaurant }) => {
 
 RestaurantEntry.propTypes = {
   restaurant: PropTypes.object.isRequired,
-  showMap: PropTypes.bool
+  showMap: PropTypes.bool,
+  hidden: PropTypes.bool
 }
 
 export default RestaurantEntry


### PR DESCRIPTION
- loads the photos and reviews of the selected restaurant when 5 restaurants are left in the queue. This means the photos and reviews are almost certainly ready when the restaurantentry is shown, but the longer breaks between the last rotations means the name/bowl rotation animation should not be slowed down by it.
- works better when more than 1 restaurant is returned by allmatches
- works the same when just 1 restaurant is returned by allmatches
- should be integrated with the statistics stuff