### PR TITLE
The approval rate is now calculated from selected vs notselected

### DIFF
--- a/packages/app/src/components/RestaurantEntry/RestaurantEntry.js
+++ b/packages/app/src/components/RestaurantEntry/RestaurantEntry.js
@@ -63,13 +63,18 @@ const RestaurantEntry = ({ restaurant }) => {
         placement='right'
         overlay={
           <Tooltip >
-            {restaurant.name + ' has won the lottery ' + restaurant.resultAmount + ' times. '
+            {/*restaurant.name + ' has won the lottery ' + restaurant.resultAmount + ' times. '
               + 'It was selected ' + restaurant.selectedAmount + ' times. '
-              + '(Re-rolled ' + restaurant.notSelectedAmount + ' times)'}
+        + '(Re-rolled ' + restaurant.notSelectedAmount + ' times)'*/}
+
+            {'* ' + restaurant.name + ' has been selected ' + restaurant.selectedAmount + ' times. '
+              + 'It has been re-rolled ' + restaurant.notSelectedAmount + ' times. '
+              + '(Total number of times as the lottery result: ' + restaurant.resultAmount + ')'
+            } 
           </Tooltip>
         } >
         <p className='randomizer-resultApproval'>
-          {appName} users picked this restaurant {Math.round((restaurant.selectedAmount / restaurant.resultAmount * 100))}% of the time
+          {appName} users picked this restaurant {Math.round((restaurant.selectedAmount / restaurant.notSelectedAmount * 100))}% of the time &#42;
         </p>
       </OverlayTrigger>
       }

--- a/packages/app/src/components/RestaurantEntry/RestaurantEntry.js
+++ b/packages/app/src/components/RestaurantEntry/RestaurantEntry.js
@@ -63,10 +63,6 @@ const RestaurantEntry = ({ restaurant }) => {
         placement='right'
         overlay={
           <Tooltip >
-            {/*restaurant.name + ' has won the lottery ' + restaurant.resultAmount + ' times. '
-              + 'It was selected ' + restaurant.selectedAmount + ' times. '
-        + '(Re-rolled ' + restaurant.notSelectedAmount + ' times)'*/}
-
             {'* ' + restaurant.name + ' has been selected ' + restaurant.selectedAmount + ' times. '
               + 'It has been re-rolled ' + restaurant.notSelectedAmount + ' times. '
               + '(Total number of times as the lottery result: ' + restaurant.resultAmount + ')'


### PR DESCRIPTION
- The approval % shown when the lottery finishes is now calculated from how many times users actively selected the restaurant or re-rolled it (previously: # of active picks vs. # of times the restaurant was the lottery result)
- Updated the associated tooltip to reflect the change