### PR TITLE
Fixed statistics backend

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -18,6 +18,7 @@
     "@material-ui/core": "^4.9.5",
     "@material-ui/icons": "^4.9.1",
     "axios": "^0.19.1",
+    "chart.js": "^2.9.3",
     "leaflet": "^1.6.0",
     "mutationobserver-shim": "^0.3.3",
     "p5": "^1.0.0",

--- a/packages/app/src/App.js
+++ b/packages/app/src/App.js
@@ -1,10 +1,12 @@
 import React, { useEffect, useState } from 'react'
+import PropTypes from 'prop-types'
 import './App.css'
 import { Route, Switch, Redirect, useHistory, Link } from 'react-router-dom'
 import Randomizer from './components/Randomizer/Randomizer'
 import AddForm from './components/Restaurants/AddForm'
 import EditForm from './components/Restaurants/EditForm'
 import NotFound from './components/error/NotFound'
+import Statistics from './components/statistics/Statistics'
 import Attributions from './components/Attributions/Attributions'
 import PasswordReset from './components/auth/PasswordReset'
 import RestaurantList from './components/Restaurants/RestaurantList/RestaurantList'
@@ -34,20 +36,6 @@ const App = () => {
     setIsLoggedIn(token !== undefined)
   }, [token])
 
-  const adminRoutes =
-    <Route path="/admin" render={() =>
-      <Switch>
-        {!isLoggedIn && <Redirect to='/login' />}
-        <Route exact path="/admin/categories/add" render={() => <CategoryForm onSubmit={categoryService.add} />} />
-        <Route exact path="/admin/categories/edit/:id" render={({ match }) => <CategoryForm id={match.params.id} onSubmit={categoryService.update} />} />
-        <Route exact path="/admin/categories" render={() => <CategoryList />} />
-        <Route exact path="/admin/suggestions" render={() => <SuggestionList />} />
-        <Route exact path="/admin/users" render={() => <UserList />} />
-        <Route exact path="/admin/users/register" render={() => <RegisterForm onSubmit={(user) => authService.register(user)} />} />
-        <Redirect to={'/admin/suggestions'} />
-      </Switch>
-    } />
-
   return (
     <>
       <header className='main-navbar'>
@@ -55,20 +43,20 @@ const App = () => {
       </header>
       <section className='main-container'>
         <Switch>
-          <Route exact path="/error/404" render={() => <NotFound />} />
-          <Route exact path="/attributions" render={() => <Attributions />} />
-          <Route exact path="/admin/password-reset" render={() => <PasswordReset reset />} />
-          <Route exact path="/admin/change-password" render={() => <PasswordReset />} />
+          <Route exact path='/error/404' render={() => <NotFound />} />
+          <Route exact path='/attributions' render={() => <Attributions />} />
+          <Route exact path='/statistics' render={() => <Statistics />} />
+          <Route exact path='/admin/password-reset' render={() => <PasswordReset reset />} />
+          <Route exact path='/admin/change-password' render={() => <PasswordReset />} />
 
-          <Route exact path="/" render={() => <Randomizer />} />
-          <Route exact path="/add" render={() => <AddForm />} />
-          <Route exact path="/edit/:id" render={({ match }) => <EditForm id={match.params.id} />} />
-          <Route exact path="/restaurants" render={() => <RestaurantList />} />
-          <Route exact path="/login" render={() => isLoggedIn
+          <Route exact path='/' render={() => <Randomizer />} />
+          <Route exact path='/add' render={() => <AddForm />} />
+          <Route exact path='/edit/:id' render={({ match }) => <EditForm id={match.params.id} />} />
+          <Route exact path='/restaurants' render={() => <RestaurantList />} />
+          <Route exact path='/login' render={() => isLoggedIn
             ? <Redirect to={'/admin/suggestions'} />
             : <LoginForm changeLoginStatus={setIsLoggedIn} />} />
-          {adminRoutes}
-
+          <AdminRoute basePath='/admin' isLoggedIn={isLoggedIn} />
           <Route path="*" render={() => <Redirect to='/error/404' />} />
         </Switch>
       </section>
@@ -79,6 +67,25 @@ const App = () => {
 
     </>
   )
+}
+
+const AdminRoute = ({ isLoggedIn, basePath }) =>
+  <Route path="/admin" render={() =>
+    <Switch>
+      {!isLoggedIn && <Redirect to='/login' />}
+      <Route exact path={`${basePath}/categories/add`} render={() => <CategoryForm onSubmit={categoryService.add} />} />
+      <Route exact path={`${basePath}/categories/edit/:id`} render={({ match }) => <CategoryForm id={match.params.id} onSubmit={categoryService.update} />} />
+      <Route exact path={`${basePath}/categories`} render={() => <CategoryList />} />
+      <Route exact path={`${basePath}/suggestions`} render={() => <SuggestionList />} />
+      <Route exact path={`${basePath}/users`} render={() => <UserList />} />
+      <Route exact path={`${basePath}/users/register`} render={() => <RegisterForm onSubmit={(user) => authService.register(user)} />} />
+      <Redirect to={'/admin/suggestions'} />
+    </Switch>
+  } />
+
+AdminRoute.propTypes = {
+  isLoggedIn: PropTypes.bool.isRequired,
+  basePath: PropTypes.string.isRequired,
 }
 
 export default App

--- a/packages/app/src/components/NavBar.css
+++ b/packages/app/src/components/NavBar.css
@@ -1,0 +1,3 @@
+.main-navbar > nav > * > * > a {
+    max-height: 40px;
+}

--- a/packages/app/src/components/NavBar.js
+++ b/packages/app/src/components/NavBar.js
@@ -1,9 +1,14 @@
 import React from 'react'
 import { Nav, Navbar, Button } from 'react-bootstrap'
+import Equalizer from '@material-ui/icons/Equalizer'
+import Lock from '@material-ui/icons/Lock'
+import LockOpen from '@material-ui/icons/LockOpen'
 import { Link, useHistory } from 'react-router-dom'
 import PropTypes from 'prop-types'
 
 import { appName } from '../config'
+import './NavBar.css'
+
 import authService from '../services/authentication'
 
 const NavBar = ({ loggedIn, changeLoginStatus }) => {
@@ -60,9 +65,14 @@ const NavBar = ({ loggedIn, changeLoginStatus }) => {
           </Nav.Item>
         </Nav>
         <Nav>
+          <Nav.Link as={Link} href='#' data-testid='statistics-link' to='/statistics'>
+            Statistics <Equalizer />
+          </Nav.Link>
+        </Nav>
+        <Nav>
           {loggedIn
-            ? <Button data-testid='logout-button' onClick={logout} variant="danger" className="mr-auto">Logout</Button>
-            : <Button data-testid='admin-button' onClick={() => history.push('/login')} variant='light' size='sm' className='mr-auto'>Admin Login</Button>
+            ? <Button data-testid='logout-button' onClick={logout} variant="danger" className="ml-auto"><Lock /> Logout</Button>
+            : <Button data-testid='admin-button' onClick={() => history.push('/login')} variant='outline-secondary' size='sm' className='ml-auto'><LockOpen /> Admin Login</Button>
           }
         </Nav>
       </Navbar.Collapse>

--- a/packages/app/src/components/statistics/Bar.js
+++ b/packages/app/src/components/statistics/Bar.js
@@ -6,39 +6,40 @@ import Chart from 'chart.js'
 const roundToTwoDecimals = (x) => Math.round((x + Number.EPSILON) * 100) / 100
 
 /**
- * Renders a doghnut chart from the data provided.
+ * Renders a bar chart from the data provided. For details on what's going on, see the doghnut component.
  */
-const Doughnut = ({ title, data }) => {
-  /** 
-   * Reference to the chart canvas container. This is not directly related to React state (thus not useState),
-   * as we only need this in order to tell the Chart.js where it should render. Chart.js handles the rendering
-   * here, not React.
-   */
+const Bar = ({ title, data }) => {
   const chartRef = useRef()
 
-  // Once the component is mounted, create the chart
   useEffect(() => {
-    // Grab 2d canvas for Chart.js
     const context = chartRef.current.getContext('2d')
 
-    // Read labels/values from input data
     const labels = data.map((entry) => entry.label)
     const nTotal = data.map((entry) => entry.num).reduce((a, b) => a + b, 0)
     const values = data.map((entry) => (nTotal > 0 ? roundToTwoDecimals(entry.num / nTotal) : 0.5) * 100)
 
-    // Create the chart
+    
+    /**
+     * Create strings with format `rgb(r, g, b)` where components are in range [0, 255]
+     */
+    const random255 = () => Math.round(Math.random() * 255)
+    const getRandomColor = () => `rgb(${random255()}, ${random255()}, ${random255()}, 0.85)`
+
     new Chart(context, {
-      type: 'doughnut',
+      type: 'bar',
       data: {
         labels: labels,
         datasets: [
           {
             backgroundColor: [
-              'rgba(128, 240, 0, 0.85)',
-              'rgba(220, 51, 0, 0.85)',
+              getRandomColor(),
+              getRandomColor(),
+              getRandomColor(),
+              getRandomColor(),
+              getRandomColor(),
             ],
             data: values,
-            borderWidth: 2
+            borderWidth: 4
           }
         ]
       },
@@ -49,26 +50,37 @@ const Doughnut = ({ title, data }) => {
           fontColor: 'white',
           fontSize: '24'
         },
-        legend: {
-          display: true,
-          rtl: true,
-          position: 'bottom',
-          labels: {
-            fontColor: 'white'
-          }
+        scales: {
+          yAxes: [{
+            ticks: {
+              fontColor: 'white',
+              fontSize: 18,
+              stepSize: 10,
+              beginAtZero: true
+            }
+          }],
+          xAxes: [{
+            ticks: {
+              fontColor: 'white',
+              fontSize: 14,
+              stepSize: 1,
+              beginAtZero: true
+            }
+          }]
         },
+        legend: { display: false, },
       }
     })
   }, [data, title])
 
   return (
     <div>
-      <canvas width={400} height={400} ref={chartRef} />
+      <canvas width={600} height={400} ref={chartRef} />
     </div>
   )
 }
 
-Doughnut.propTypes = {
+Bar.propTypes = {
   title: PropTypes.string.isRequired,
   data: PropTypes.arrayOf(PropTypes.shape({
     label: PropTypes.string.isRequired,
@@ -76,4 +88,4 @@ Doughnut.propTypes = {
   })).isRequired,
 }
 
-export default Doughnut
+export default Bar

--- a/packages/app/src/components/statistics/Doughnut.js
+++ b/packages/app/src/components/statistics/Doughnut.js
@@ -1,0 +1,78 @@
+import React, { useRef, useEffect } from 'react'
+import PropTypes from 'prop-types'
+
+import Chart from 'chart.js'
+
+const roundToTwoDecimals = (x) => Math.round((x + Number.EPSILON) * 100) / 100
+
+/**
+ * Renders a doghnut chart from the data provided.
+ */
+const Doughnut = ({ title, data }) => {
+  /** 
+   * Reference to the chart canvas container. This is not directly related to React state (thus not useState),
+   * as we only need this in order to tell the Chart.js where it should render. Chart.js handles the rendering
+   * here, not React.
+   */
+  const chartRef = useRef()
+
+  // Once the component is mounted, create the chart
+  useEffect(() => {
+    // Grab 2d canvas for Chart.js
+    const context = chartRef.current.getContext('2d')
+
+    // Read labels/values from input data
+    const labels = data.map((entry) => entry.label)
+    const nTotal = data.map((entry) => entry.num).reduce((a, b) => a + b, 0)
+    const values = data.map((entry) => (nTotal > 0 ? roundToTwoDecimals(entry.num / nTotal) : 0.5) * 100)
+
+    // Create the chart
+    new Chart(context, {
+      type: 'doughnut',
+      data: {
+        labels: labels,
+        datasets: [
+          {
+            backgroundColor: [
+              'rgb(128, 255, 0)',
+              'rgb(255, 51, 0)',
+            ],
+            data: values,
+            borderWidth: 2
+          }
+        ]
+      },
+      options: {
+        title: {
+          display: true,
+          text: title,
+          fontColor: 'white'
+        },
+        legend: {
+          display: true,
+          rtl: true,
+          position: 'bottom',
+          labels: {
+            fontColor: 'white'
+          }
+        },
+      }
+    })
+  }, [data, title])
+
+  return (
+    <div>
+      <canvas width={400} height={400} ref={chartRef} />
+    </div>
+  )
+}
+
+Doughnut.propTypes = {
+  title: PropTypes.string.isRequired,
+  data: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    num: PropTypes.number.isRequired,
+  })).isRequired,
+}
+
+export default Doughnut

--- a/packages/app/src/components/statistics/Statistics.js
+++ b/packages/app/src/components/statistics/Statistics.js
@@ -1,0 +1,46 @@
+import React from 'react'
+import Doughnut from './Doughnut'
+
+import styles from './Statistics.module.css'
+
+const Statistics = () =>
+  <div>
+    <h1>Let&apos;s run the numbers!</h1>
+    <Charts />
+  </div>
+
+const Charts = () => {
+  const lazyData = [
+    {
+      label: 'Responsible users',
+      num: 40,
+    },
+    {
+      label: 'Slackers',
+      num: 60,
+    }
+  ]
+
+  const reRollData = [
+    {
+      label: 'Accepted',
+      num: 80,
+    },
+    {
+      label: 'Re-rolled',
+      num: 20,
+    }
+  ]
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.doughnuts}>
+        <Doughnut title='Lazy vs. responsible' data={lazyData} />
+        <Doughnut title='Accept vs. Re-roll' data={reRollData} />
+      </div>
+    </div>
+  )
+}
+
+
+export default Statistics

--- a/packages/app/src/components/statistics/Statistics.js
+++ b/packages/app/src/components/statistics/Statistics.js
@@ -28,6 +28,8 @@ const Statistics = () => {
     return <div>Loading...</div>
   }
 
+  console.log('stats:', stats)
+
   return (
     <div className={styles.view}>
       <h1>Let&apos;s run the numbers!</h1>
@@ -110,11 +112,11 @@ const TopResultBars = ({ data }) => {
 }
 
 Charts.propTypes = {
-  stats: PropTypes.shape({
+  stats: PropTypes.arrayOf(PropTypes.shape({
     notDecidedAmount: PropTypes.number.isRequired,
     selectedAmount: PropTypes.number.isRequired,
     notSelectedAmount: PropTypes.number.isRequired,
-  }).isRequired,
+  })).isRequired,
   topAccepted: PropTypes.array.isRequired,
   topResult: PropTypes.array.isRequired, 
 }

--- a/packages/app/src/components/statistics/Statistics.js
+++ b/packages/app/src/components/statistics/Statistics.js
@@ -1,46 +1,137 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
+import PropTypes from 'prop-types'
 import Doughnut from './Doughnut'
+import Bar from './Bar'
+
+import { shuffle } from '../../util/shuffle'
+
+import statsService from '../../services/statistics'
 
 import styles from './Statistics.module.css'
 
-const Statistics = () =>
-  <div>
-    <h1>Let&apos;s run the numbers!</h1>
-    <Charts />
-  </div>
+const Statistics = () => {
+  const [stats, setStats] = useState()
+  const [topAccepted, setTopAccepted] = useState()
+  const [topResult, setTopResult] = useState()
 
-const Charts = () => {
-  const lazyData = [
-    {
-      label: 'Responsible users',
-      num: 40,
-    },
-    {
-      label: 'Slackers',
-      num: 60,
+  useEffect(() => {
+    const fetchStats = async () => {
+      setStats(await statsService.getAll())
+      setTopAccepted(await statsService.getTopAccepted())
+      setTopResult(await statsService.getTopResult())
     }
-  ]
 
-  const reRollData = [
-    {
-      label: 'Accepted',
-      num: 80,
-    },
-    {
-      label: 'Re-rolled',
-      num: 20,
-    }
-  ]
+    fetchStats()
+  }, [])
+
+  if (!stats || !topAccepted || !topResult) {
+    return <div>Loading...</div>
+  }
 
   return (
-    <div className={styles.container}>
-      <div className={styles.doughnuts}>
-        <Doughnut title='Lazy vs. responsible' data={lazyData} />
-        <Doughnut title='Accept vs. Re-roll' data={reRollData} />
-      </div>
+    <div className={styles.view}>
+      <h1>Let&apos;s run the numbers!</h1>
+      <Charts stats={stats} topAccepted={topAccepted} topResult={topResult} />
     </div>
   )
 }
 
+const Charts = ({ stats, topAccepted, topResult }) => {
+  return (
+    <div className={styles.container}>
+      <TopAcceptedBars data={topAccepted} />
+      <TopResultBars data={topResult} />
+      <AcceptanceDoughnuts
+        nLazy={stats.notDecidedAmount || 60}
+        nResponsible={stats.selectedAmount || 40}
+        nAccept={stats.selectedAmount || 80}
+        nReRoll={stats.notSelectedAmount || 20} />
+    </div>
+  )
+}
+
+const AcceptanceDoughnuts = ({ nLazy, nResponsible, nAccept, nReRoll }) => {
+  const lazyData = [
+    { label: 'Responsible users', num: nResponsible, },
+    { label: 'Slackers', num: nLazy, },
+  ]
+  const reRollData = [
+    { label: 'Accepted', num: nAccept, },
+    { label: 'Re-rolled', num: nReRoll, },
+  ]
+
+  return (
+    <div className={styles.statistics}>
+      <Doughnut title='Lazy vs. responsible' data={lazyData} />
+      <Doughnut title='Accept vs. Re-roll' data={reRollData} />
+      <p>
+        {'This statistic visualizes the "laziness" of the users and the "acceptance rate" of the restaurant rolls. Laziness is the percentage of times when users did not press either of the "Ok, I\'m eating here" or "Nope, re-roll" -buttons. Acceptance rate is the ratio between accepted restaurants and re-rolls.'}
+      </p>
+    </div>
+  )
+}
+
+const TopAcceptedBars = ({ data }) => {
+  const parsedData = data.map(entry => (
+    {
+      label: entry.name,
+      num: entry.selectedAmount,
+    }
+  ))
+  shuffle(parsedData)
+
+  return (
+    <div className={styles.statistics}>
+      <Bar title='Top Accepted' data={parsedData} />
+      <p>
+        {'This chart visualizes the top-5 acceptance counts for restaurants. This is the number of times the users have clicked the "Ok! I\'m going there" -button for the restaurant.'}
+      </p>
+    </div>
+  )
+}
+
+const TopResultBars = ({ data }) => {
+  const parsedData = data.map(entry => (
+    {
+      label: entry.name,
+      num: entry.resultAmount,
+    }
+  ))
+  shuffle(parsedData)
+
+  return (
+    <div className={styles.statistics}>
+      <Bar title='Top Lottery Winners' data={parsedData} />
+      <p>
+        This chart visualizes the top-5 lottery winners. These are the restaurants that have most often ended up as the result displayed to user at the end of the lottery.
+      </p>
+    </div>
+  )
+}
+
+Charts.propTypes = {
+  stats: PropTypes.shape({
+    notDecidedAmount: PropTypes.number.isRequired,
+    selectedAmount: PropTypes.number.isRequired,
+    notSelectedAmount: PropTypes.number.isRequired,
+  }).isRequired,
+  topAccepted: PropTypes.array.isRequired,
+  topResult: PropTypes.array.isRequired, 
+}
+
+AcceptanceDoughnuts.propTypes = {
+  nLazy: PropTypes.number.isRequired,
+  nResponsible: PropTypes.number.isRequired,
+  nAccept: PropTypes.number.isRequired,
+  nReRoll: PropTypes.number.isRequired,
+}
+
+TopResultBars.propTypes = {
+  data: PropTypes.array.isRequired,
+}
+
+TopAcceptedBars.propTypes = {
+  data: PropTypes.array.isRequired,
+}
 
 export default Statistics

--- a/packages/app/src/components/statistics/Statistics.js
+++ b/packages/app/src/components/statistics/Statistics.js
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types'
 import Doughnut from './Doughnut'
 import Bar from './Bar'
 
-import { shuffle } from '../../util/shuffle'
-
 import statsService from '../../services/statistics'
 
 import styles from './Statistics.module.css'
@@ -28,8 +26,6 @@ const Statistics = () => {
     return <div>Loading...</div>
   }
 
-  console.log('stats:', stats)
-
   return (
     <div className={styles.view}>
       <h1>Let&apos;s run the numbers!</h1>
@@ -44,10 +40,10 @@ const Charts = ({ stats, topAccepted, topResult }) => {
       <TopAcceptedBars data={topAccepted} />
       <TopResultBars data={topResult} />
       <AcceptanceDoughnuts
-        nLazy={stats.notDecidedAmount || 60}
-        nResponsible={stats.selectedAmount || 40}
-        nAccept={stats.selectedAmount || 80}
-        nReRoll={stats.notSelectedAmount || 20} />
+        nLazy={(stats.totalAmount - stats.decidedAmount)}
+        nResponsible={stats.decidedAmount}
+        nAccept={stats.selectedAmount}
+        nReRoll={stats.notSelectedAmount} />
     </div>
   )
 }
@@ -77,10 +73,9 @@ const TopAcceptedBars = ({ data }) => {
   const parsedData = data.map(entry => (
     {
       label: entry.name,
-      num: entry.selectedAmount,
+      num: entry.selectedAmount / entry.resultAmount,
     }
   ))
-  shuffle(parsedData)
 
   return (
     <div className={styles.statistics}>
@@ -99,7 +94,6 @@ const TopResultBars = ({ data }) => {
       num: entry.resultAmount,
     }
   ))
-  shuffle(parsedData)
 
   return (
     <div className={styles.statistics}>
@@ -112,13 +106,14 @@ const TopResultBars = ({ data }) => {
 }
 
 Charts.propTypes = {
-  stats: PropTypes.arrayOf(PropTypes.shape({
-    notDecidedAmount: PropTypes.number.isRequired,
+  stats: PropTypes.shape({
+    decidedAmount: PropTypes.number.isRequired,
+    totalAmount: PropTypes.number.isRequired,
     selectedAmount: PropTypes.number.isRequired,
     notSelectedAmount: PropTypes.number.isRequired,
-  })).isRequired,
+  }).isRequired,
   topAccepted: PropTypes.array.isRequired,
-  topResult: PropTypes.array.isRequired, 
+  topResult: PropTypes.array.isRequired,
 }
 
 AcceptanceDoughnuts.propTypes = {

--- a/packages/app/src/components/statistics/Statistics.module.css
+++ b/packages/app/src/components/statistics/Statistics.module.css
@@ -6,6 +6,10 @@
   margin: 2em;
 }
 
+.view > h1 {
+  text-align: center;
+}
+
 .container {
   margin-bottom: 1em;
 }

--- a/packages/app/src/components/statistics/Statistics.module.css
+++ b/packages/app/src/components/statistics/Statistics.module.css
@@ -1,11 +1,28 @@
-.container {
+.view {
   padding-left: 3em;
   padding-right: 3em;
   padding-top: 2em;
+  padding-bottom: 2em;
+  margin: 2em;
+}
+
+.container {
   margin-bottom: 1em;
+}
+
+.statistics {
+  padding-bottom: 0.5em;
+  margin-bottom: 1.5em;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
   background-color: rgba(0, 0, 0, 0.5);
 }
 
-.doughnuts {
-  display: flex;
+.statistics > p {
+  max-width: 60vw;
+  border-radius: 1em;
+  background-color: rgba(0, 0, 0, 0.4);
+  padding: 1em;
+  line-height: 1.1em;
 }

--- a/packages/app/src/components/statistics/Statistics.module.css
+++ b/packages/app/src/components/statistics/Statistics.module.css
@@ -1,0 +1,11 @@
+.container {
+  padding-left: 3em;
+  padding-right: 3em;
+  padding-top: 2em;
+  margin-bottom: 1em;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.doughnuts {
+  display: flex;
+}

--- a/packages/app/src/services/statistics.js
+++ b/packages/app/src/services/statistics.js
@@ -20,5 +20,5 @@ const getTopResult = async () => {
 export default {
   getAll,
   getTopAccepted,
-  getTopResult,
+  getTopResult
 }

--- a/packages/app/src/services/statistics.js
+++ b/packages/app/src/services/statistics.js
@@ -1,0 +1,24 @@
+import axios from 'axios'
+
+const baseUrl = '/api/statistics'
+
+const getAll = async () => {
+  const response = await axios.get(`${baseUrl}/`)
+  return response.data
+}
+
+const getTopAccepted = async () => {
+  const response = await axios.get(`${baseUrl}/topAccepted/`)
+  return response.data
+}
+
+const getTopResult = async () => {
+  const response = await axios.get(`${baseUrl}/topResult/`)
+  return response.data
+}
+
+export default {
+  getAll,
+  getTopAccepted,
+  getTopResult,
+}

--- a/packages/backend/src/app.js
+++ b/packages/backend/src/app.js
@@ -8,7 +8,7 @@ const categoriesRouter = require('./controllers/categories')
 const authRouter = require('./controllers/auth')
 const suggestionRouter = require('./controllers/suggestions')
 const placesRouter = require('./controllers/places')
-const statisticsRouter = require('./controllers/statistics')
+const { statisticsRouter } = require('./controllers/statistics')
 
 const config = require('./config')
 

--- a/packages/backend/src/controllers/restaurants.js
+++ b/packages/backend/src/controllers/restaurants.js
@@ -2,7 +2,10 @@ const restaurantsRouter = require('express').Router()
 const Restaurant = require('../models/restaurant')
 const Category = require('../models/category')
 const Suggestion = require('../models/suggestion')
+const Statistics = require('../models/statistics')
 const authorization = require('../util/authorization')
+
+const { findOrCreateStatistics } = require('./statistics')
 
 const tryCreateRestaurant = async (restaurant) => {
   const created = await new Restaurant(restaurant).save()
@@ -177,6 +180,11 @@ restaurantsRouter.put('/increaseResult/:id', async (request, response, next) => 
     const restaurant = await Restaurant.findById(request.params.id)
     restaurant.resultAmount = restaurant.resultAmount + 1
     await Restaurant.findByIdAndUpdate(restaurant.id, restaurant)
+
+    const statistics = await findOrCreateStatistics()
+    statistics.totalAmount = statistics.totalAmount + 1
+    await statistics.save()
+
     return response.status(200).end()
   } catch (error) {
     next(error)
@@ -189,6 +197,12 @@ restaurantsRouter.put('/increaseSelected/:id', async (request, response, next) =
     const restaurant = await Restaurant.findById(request.params.id)
     restaurant.selectedAmount = restaurant.selectedAmount + 1
     await Restaurant.findByIdAndUpdate(restaurant.id, restaurant)
+
+    const statistics = await findOrCreateStatistics()
+    statistics.selectedAmount = statistics.selectedAmount + 1
+    statistics.decidedAmount = statistics.decidedAmount + 1
+    await statistics.save()
+
     return response.status(200).end()
   } catch (error) {
     next(error)
@@ -201,6 +215,12 @@ restaurantsRouter.put('/increaseNotSelected/:id', async (request, response, next
     const restaurant = await Restaurant.findById(request.params.id)
     restaurant.notSelectedAmount = restaurant.notSelectedAmount + 1
     await Restaurant.findByIdAndUpdate(restaurant.id, restaurant)
+
+    const statistics = await findOrCreateStatistics()
+    statistics.notSelectedAmount = statistics.notSelectedAmount + 1
+    statistics.decidedAmount = statistics.decidedAmount + 1
+    await statistics.save()
+
     return response.status(200).end()
   } catch (error) {
     next(error)

--- a/packages/backend/src/controllers/statistics.js
+++ b/packages/backend/src/controllers/statistics.js
@@ -21,10 +21,10 @@ statisticsRouter.get('/topAccepted/', async (request, response, next, n = 5) => 
     const restaurants = await Restaurant
       .find({}).populate('categories')
     restaurants.sort((a, b) => {
-      if (a.notSelectedAmount === b.notSelectedAmount) {
+      if (a.selectedAmount/a.resultAmount === b.selectedAmount/b.resultAmount) {
         return b.resultAmount - a.resultAmount
       } else {
-        return a.notSelectedAmount / a.resultAmount - b.notSelectedAmount / b.resultAmount
+        return b.selectedAmount / b.resultAmount - a.selectedAmount / a.resultAmount
 
       }
     })

--- a/packages/backend/src/controllers/statistics.js
+++ b/packages/backend/src/controllers/statistics.js
@@ -3,16 +3,16 @@ const Statistics = require('../models/statistics')
 const Restaurant = require('../models/restaurant')
 const Category = require('../models/category')
 
-// getAll
+// find or create
 statisticsRouter.get('/', async (request, response, next) => {
-  try {
-    const statistics = await Statistics
-      .find({})
-    return response.json(statistics.map(rest => rest.toJSON()))
+  const statistics = await Statistics.findOne({})
+  if (!statistics) {
+    const statistics = new Statistics({})
+
+    const saved = await statistics.save()
+    return response.json(saved.toJSON())
   }
-  catch (error) {
-    next(error)
-  }
+  return response.json(statistics.toJSON())
 })
 
 // get top n accepted
@@ -89,9 +89,9 @@ statisticsRouter.get('/topCategories', async (request, response, next, n = 5) =>
 })
 
 // increase lotteryAmount
-statisticsRouter.put('/lotteryAmount/:id', async (request, response, next) => {
+statisticsRouter.put('/lotteryAmount/', async (request, response, next) => {
   try {
-    const statistics = await Statistics.findById(request.params.id)
+    const statistics = await Statistics.findOne()
     statistics.lotteryAmount = statistics.lotteryAmount + 1
     await Statistics.findByIdAndUpdate(statistics.id, statistics)
     return response.status(200).end()
@@ -101,9 +101,9 @@ statisticsRouter.put('/lotteryAmount/:id', async (request, response, next) => {
 })
 
 // increase notSelectedAmount
-statisticsRouter.put('/notSelectedAmount/:id', async (request, response, next) => {
+statisticsRouter.put('/notSelectedAmount/', async (request, response, next) => {
   try {
-    const statistics = await Statistics.findById(request.params.id)
+    const statistics = await Statistics.findOne()
     statistics.notSelectedAmount = statistics.notSelectedAmount + 1
     await Statistics.findByIdAndUpdate(statistics.id, statistics)
     return response.status(200).end()
@@ -113,9 +113,9 @@ statisticsRouter.put('/notSelectedAmount/:id', async (request, response, next) =
 })
 
 // increase selectedAmount
-statisticsRouter.put('/selectedAmount/:id', async (request, response, next) => {
+statisticsRouter.put('/selectedAmount/', async (request, response, next) => {
   try {
-    const statistics = await Statistics.findById(request.params.id)
+    const statistics = await Statistics.findOne()
     statistics.selectedAmount = statistics.selectedAmount + 1
     await Statistics.findByIdAndUpdate(statistics.id, statistics)
     return response.status(200).end()
@@ -125,9 +125,9 @@ statisticsRouter.put('/selectedAmount/:id', async (request, response, next) => {
 })
 
 // increase notDecidedAmount
-statisticsRouter.put('/notDecidedAmount/:id', async (request, response, next) => {
+statisticsRouter.put('/notDecidedAmount/', async (request, response, next) => {
   try {
-    const statistics = await Statistics.findById(request.params.id)
+    const statistics = await Statistics.findOne()
     statistics.notDecidedAmount = statistics.notDecidedAmount + 1
     await Statistics.findByIdAndUpdate(statistics.id, statistics)
     return response.status(200).end()

--- a/packages/backend/src/controllers/statistics.test.js
+++ b/packages/backend/src/controllers/statistics.test.js
@@ -98,21 +98,17 @@ const getAdditionalCategories = (res1, res2, res3, ) => [
   },
 ]
 
+let restaurants, server, statistics
 beforeEach(async () => {
   dbUtil.connect()
   server = supertest(app)
   statistics = await dbUtil.createRowsFrom(Statistics, statisticsData)
   restaurants = await dbUtil.createRowsFrom(Restaurant, restaurantData)
-  id = statistics[0].id
-  user = await dbUtil.createUser('jaskajoku', 'kissa')
-  token = authorization.createToken(user._id, user.username)
 })
 
 afterEach(async () => {
   await dbUtil.cleanupAndDisconnect()
 })
-
-
 
 test('get request to /api/statistics/topAccepted returns the right restaurants in the right order', async () => {
   const response = await server.get('/api/statistics/topAccepted')
@@ -159,38 +155,48 @@ test('get request to /api/statistics returns statistics', async () => {
   expect(contents.lotteryAmount).toBe(statistics[0].lotteryAmount)
 })
 
-test('put request to /api/lotteryAmount/ increases lotteryAmount', async () => {
-  const expectedAmount = statistics[0].lotteryAmount + 1
+test('put request to /api/restaurants/increaseResult/:id increases total', async () => {
+  const expectedAmount = statistics[0].totalAmount + 1
   await server
-    .put('/api/statistics/lotteryAmount/')
+    .put(`/api/restaurants/increaseResult/${restaurants[0].id}`)
     .expect(200)
   const response = await server.get('/api/statistics')
-  expect(response.body.lotteryAmount).toBe(expectedAmount)
+  expect(response.body.totalAmount).toBe(expectedAmount)
 })
 
-test('put request to /api/selectedAmount/ increases selectedAmount', async () => {
+test('put request to /api/restaurants/increaseSelected/:id increases selectedAmount', async () => {
   const expectedAmount = statistics[0].selectedAmount + 1
   await server
-    .put('/api/statistics/selectedAmount/')
+    .put(`/api/restaurants/increaseSelected/${restaurants[0].id}`)
     .expect(200)
   const response = await server.get('/api/statistics')
   expect(response.body.selectedAmount).toBe(expectedAmount)
 })
 
-test('put request to /api/notSelectedAmount/ increases notSelectedAmount', async () => {
+test('put request to /api/restaurants/increaseNotSelected/:id increases notSelectedAmount', async () => {
   const expectedAmount = statistics[0].notSelectedAmount + 1
   await server
-    .put('/api/statistics/notSelectedAmount/')
+    .put(`/api/restaurants/increaseNotSelected/${restaurants[0].id}`)
     .expect(200)
   const response = await server.get('/api/statistics')
   expect(response.body.notSelectedAmount).toBe(expectedAmount)
 })
 
-test('put request to /api/notDecidedAmount/ increases notDecidedAmount', async () => {
-  const expectedAmount = statistics[0].notDecidedAmount + 1
+test('put request to /api/restaurants/increaseSelected/:id increases decidedAmount', async () => {
+  const expectedAmount = statistics[0].decidedAmount + 1
   await server
-    .put('/api/statistics/notDecidedAmount/')
+    .put(`/api/restaurants/increaseSelected/${restaurants[0].id}`)
     .expect(200)
   const response = await server.get('/api/statistics')
-  expect(response.body.notDecidedAmount).toBe(expectedAmount)
+  expect(response.body.decidedAmount).toBe(expectedAmount)
 })
+
+test('put request to /api/restaurants/increaseNotSelected/:id increases decidedAmount', async () => {
+  const expectedAmount = statistics[0].decidedAmount + 1
+  await server
+    .put(`/api/restaurants/increaseNotSelected/${restaurants[0].id}`)
+    .expect(200)
+  const response = await server.get('/api/statistics')
+  expect(response.body.decidedAmount).toBe(expectedAmount)
+})
+

--- a/packages/backend/src/controllers/statistics.test.js
+++ b/packages/backend/src/controllers/statistics.test.js
@@ -95,6 +95,8 @@ afterEach(async () => {
   await dbUtil.cleanupAndDisconnect()
 })
 
+
+
 test('get request to /api/statistics/topAccepted returns the right restaurants in the right order', async () => {
   const response = await server.get('/api/statistics/topAccepted')
   const contents = response.body
@@ -135,41 +137,41 @@ test('get request to /api/statistics/topCategories returns the right categories 
 test('get request to /api/statistics returns statistics', async () => {
   const response = await server.get('/api/statistics')
   const contents = response.body
-  expect(contents.length).toBe(1)
+  expect(contents.lotteryAmount).toBe(statistics[0].lotteryAmount)
 })
 
-test('put request to /api/lotteryAmount/:id increases lotteryAmount', async () => {
+test('put request to /api/lotteryAmount/ increases lotteryAmount', async () => {
   const expectedAmount = statistics[0].lotteryAmount + 1
   await server
-    .put(`/api/statistics/lotteryAmount/${id}`)
+    .put(`/api/statistics/lotteryAmount/`)
     .expect(200)
   const response = await server.get('/api/statistics')
-  expect(response.body[0].lotteryAmount).toBe(expectedAmount)
+  expect(response.body.lotteryAmount).toBe(expectedAmount)
 })
 
-test('put request to /api/selectedAmount/:id increases selectedAmount', async () => {
+test('put request to /api/selectedAmount/ increases selectedAmount', async () => {
   const expectedAmount = statistics[0].selectedAmount + 1
   await server
-    .put(`/api/statistics/selectedAmount/${id}`)
+    .put(`/api/statistics/selectedAmount/`)
     .expect(200)
   const response = await server.get('/api/statistics')
-  expect(response.body[0].selectedAmount).toBe(expectedAmount)
+  expect(response.body.selectedAmount).toBe(expectedAmount)
 })
 
-test('put request to /api/notSelectedAmount/:id increases notSelectedAmount', async () => {
+test('put request to /api/notSelectedAmount/ increases notSelectedAmount', async () => {
   const expectedAmount = statistics[0].notSelectedAmount + 1
   await server
-    .put(`/api/statistics/notSelectedAmount/${id}`)
+    .put(`/api/statistics/notSelectedAmount/`)
     .expect(200)
   const response = await server.get('/api/statistics')
-  expect(response.body[0].notSelectedAmount).toBe(expectedAmount)
+  expect(response.body.notSelectedAmount).toBe(expectedAmount)
 })
 
-test('put request to /api/notDecidedAmount/:id increases notDecidedAmount', async () => {
+test('put request to /api/notDecidedAmount/ increases notDecidedAmount', async () => {
   const expectedAmount = statistics[0].notDecidedAmount + 1
   await server
-    .put(`/api/statistics/notDecidedAmount/${id}`)
+    .put(`/api/statistics/notDecidedAmount/`)
     .expect(200)
   const response = await server.get('/api/statistics')
-  expect(response.body[0].notDecidedAmount).toBe(expectedAmount)
+  expect(response.body.notDecidedAmount).toBe(expectedAmount)
 })

--- a/packages/backend/src/controllers/statistics.test.js
+++ b/packages/backend/src/controllers/statistics.test.js
@@ -26,6 +26,7 @@ const restaurantData = [
     },
     distance: 300,
     notSelectedAmount: 80,
+    selectedAmount: 10,
     resultAmount: 99
   },
   {
@@ -38,6 +39,7 @@ const restaurantData = [
     },
     distance: 500,
     notSelectedAmount: 1,
+    selectedAmount: 80,
     resultAmount: 102
   },
   {
@@ -50,6 +52,7 @@ const restaurantData = [
     },
     distance: 700,
     notSelectedAmount: 50,
+    selectedAmount: 50,
     resultAmount: 101
   },
   {
@@ -62,7 +65,21 @@ const restaurantData = [
     },
     distance: 707,
     notSelectedAmount: 80,
+    selectedAmount: 12,
     resultAmount: 90
+  },
+  {
+    name: 'Steissin hese',
+    url: 'https://www.steissin-hese.fi',
+    address: 'Jokukatu 4',
+    coordinates: {
+      latitude: 26,
+      longitude: 62
+    },
+    distance: 70,
+    notSelectedAmount: 0,
+    selectedAmount: 0,
+    resultAmount: 0
   },
 ]
 
@@ -102,8 +119,9 @@ test('get request to /api/statistics/topAccepted returns the right restaurants i
   const contents = response.body
   expect(contents[0].name).toBe(restaurants[1].name)
   expect(contents[1].name).toBe(restaurants[2].name)
-  expect(contents[2].name).toBe(restaurants[0].name)
-  expect(contents[3].name).toBe(restaurants[3].name)
+  expect(contents[2].name).toBe(restaurants[3].name)
+  expect(contents[3].name).toBe(restaurants[0].name)
+  expect(contents[4].name).toBe(restaurants[4].name)
 })
 
 test('get request to /api/statistics/topResult returns the right restaurants in the right order', async () => {
@@ -113,6 +131,7 @@ test('get request to /api/statistics/topResult returns the right restaurants in 
   expect(contents[1].name).toBe(restaurants[2].name)
   expect(contents[2].name).toBe(restaurants[0].name)
   expect(contents[3].name).toBe(restaurants[3].name)
+  expect(contents[4].name).toBe(restaurants[4].name)
 })
 
 test('get request to /api/statistics/biggestCategories returns the right categories in the right order', async () => {
@@ -143,7 +162,7 @@ test('get request to /api/statistics returns statistics', async () => {
 test('put request to /api/lotteryAmount/ increases lotteryAmount', async () => {
   const expectedAmount = statistics[0].lotteryAmount + 1
   await server
-    .put(`/api/statistics/lotteryAmount/`)
+    .put('/api/statistics/lotteryAmount/')
     .expect(200)
   const response = await server.get('/api/statistics')
   expect(response.body.lotteryAmount).toBe(expectedAmount)
@@ -152,7 +171,7 @@ test('put request to /api/lotteryAmount/ increases lotteryAmount', async () => {
 test('put request to /api/selectedAmount/ increases selectedAmount', async () => {
   const expectedAmount = statistics[0].selectedAmount + 1
   await server
-    .put(`/api/statistics/selectedAmount/`)
+    .put('/api/statistics/selectedAmount/')
     .expect(200)
   const response = await server.get('/api/statistics')
   expect(response.body.selectedAmount).toBe(expectedAmount)
@@ -161,7 +180,7 @@ test('put request to /api/selectedAmount/ increases selectedAmount', async () =>
 test('put request to /api/notSelectedAmount/ increases notSelectedAmount', async () => {
   const expectedAmount = statistics[0].notSelectedAmount + 1
   await server
-    .put(`/api/statistics/notSelectedAmount/`)
+    .put('/api/statistics/notSelectedAmount/')
     .expect(200)
   const response = await server.get('/api/statistics')
   expect(response.body.notSelectedAmount).toBe(expectedAmount)
@@ -170,7 +189,7 @@ test('put request to /api/notSelectedAmount/ increases notSelectedAmount', async
 test('put request to /api/notDecidedAmount/ increases notDecidedAmount', async () => {
   const expectedAmount = statistics[0].notDecidedAmount + 1
   await server
-    .put(`/api/statistics/notDecidedAmount/`)
+    .put('/api/statistics/notDecidedAmount/')
     .expect(200)
   const response = await server.get('/api/statistics')
   expect(response.body.notDecidedAmount).toBe(expectedAmount)

--- a/packages/backend/src/models/restaurant.js
+++ b/packages/backend/src/models/restaurant.js
@@ -1,5 +1,3 @@
-const features = require('../../../util/features')
-
 const mongoose = require('mongoose')
 mongoose.set('useFindAndModify', false)
 
@@ -44,7 +42,6 @@ const restaurantSchema = new mongoose.Schema({
   ],
   placeId: {
     type: String,
-    required: features.googleApi,
   },
   selectedAmount: {
     type: Number,

--- a/packages/backend/src/models/statistics.js
+++ b/packages/backend/src/models/statistics.js
@@ -1,10 +1,13 @@
-const features = require('../../../util/features')
-
 const mongoose = require('mongoose')
 mongoose.set('useFindAndModify', false)
 
 const statisticsSchema = new mongoose.Schema({
-  lotteryAmount: {
+  decidedAmount: {
+    type: Number,
+    required: true,
+    default: 0
+  },
+  totalAmount: {
     type: Number,
     required: true,
     default: 0
@@ -19,11 +22,6 @@ const statisticsSchema = new mongoose.Schema({
     required: true,
     default: 0
   },
-  notDecidedAmount: {
-    type: Number,
-    required: true,
-    default: 0
-  }
 })
 
 statisticsSchema.set('toJSON', {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3000,6 +3000,29 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
+chart.js@^2.9.3:
+  version "2.9.3"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-2.9.3.tgz#ae3884114dafd381bc600f5b35a189138aac1ef7"
+  integrity sha512-+2jlOobSk52c1VU6fzkh3UwqHMdSlgH1xFv9FKMqHiNCpXsGPQa/+81AFa+i3jZ253Mq9aAycPwDjnn1XbRNNw==
+  dependencies:
+    chartjs-color "^2.1.0"
+    moment "^2.10.2"
+
+chartjs-color-string@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz#1df096621c0e70720a64f4135ea171d051402f71"
+  integrity sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==
+  dependencies:
+    color-name "^1.0.0"
+
+chartjs-color@^2.1.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chartjs-color/-/chartjs-color-2.4.1.tgz#6118bba202fe1ea79dd7f7c0f9da93467296c3b0"
+  integrity sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==
+  dependencies:
+    chartjs-color-string "^0.6.0"
+    color-convert "^1.9.3"
+
 chokidar@^2.0.2, chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
@@ -3178,7 +3201,7 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^1.9.0, color-convert@^1.9.1:
+color-convert@^1.9.0, color-convert@^1.9.1, color-convert@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -7788,6 +7811,11 @@ mkdirp@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.3.tgz#4cf2e30ad45959dddea53ad97d518b6c8205e1ea"
   integrity sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g==
+
+moment@^2.10.2:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
 mongodb-memory-server-core@6.3.3:
   version "6.3.3"


### PR DESCRIPTION
- incrementing statistics values doesn't need an id anymore
- getAll => find or create
- statistics get top bugfix for cases where values are zeros. 

**EDIT** *(by @Kailari)*:
Scope for this PR extended to integrate the frontend
- Statistics page, link in the navbar
- ChartJS-based bar and doughnut charts
- [~~Yeeted~~ Yote](https://www.urbandictionary.com/define.php?term=Yeet) the `/api/statistics/incrementXXX` endpoints and moved statistics handling to restaurant endpoints. This way the statistics are handled in existing endpoints and no extra API calls are required.
- Likely fix for another `NaN` edge-case on the `/api/statistics/topAccepted` endpoint

Known issues:
- The bar charts on the statistics page do not fit very well on smaller screens. However, I did not find any easy way of controlling canvas size via CSS or how it could be made responsive otherwise