### PR TITLE
Bump CI cache version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,9 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v3-dependencies-{{ checksum "package.json" }}
+            - v4-dependencies-{{ checksum "package.json" }}
             # fallback to using the latest cache if no exact match is found
-            - v3-dependencies-
+            - v4-dependencies-
 
       - run: yarn install
 
@@ -22,7 +22,7 @@ jobs:
           paths:
             - node_modules
             - packages/**/node_modules
-          key: v3-dependencies-{{ checksum "package.json" }}
+          key: v4-dependencies-{{ checksum "package.json" }}
 
       # run tests!
       - run: yarn test


### PR DESCRIPTION
The Node container on the CI seems to have updated and bcrypt versions on the cache are now incompatible and fail tests. Trying purging caches to see if that helps.