### PR TITLE
Stats css changes to be more mobile friendly

### DIFF
--- a/packages/app/src/components/statistics/Bar.js
+++ b/packages/app/src/components/statistics/Bar.js
@@ -75,7 +75,7 @@ const Bar = ({ title, data }) => {
 
   return (
     <div>
-      <canvas width={600} height={400} ref={chartRef} />
+      <canvas width={600} height={400} ref={chartRef} style={{maxWidth:"100vw"}} />
     </div>
   )
 }

--- a/packages/app/src/components/statistics/Bar.js
+++ b/packages/app/src/components/statistics/Bar.js
@@ -75,7 +75,7 @@ const Bar = ({ title, data }) => {
 
   return (
     <div>
-      <canvas width={600} height={400} ref={chartRef} style={{maxWidth:"100vw"}} />
+      <canvas width={600} height={400} ref={chartRef} style={{maxWidth:'100vw'}} />
     </div>
   )
 }

--- a/packages/app/src/components/statistics/Doughnut.js
+++ b/packages/app/src/components/statistics/Doughnut.js
@@ -63,7 +63,7 @@ const Doughnut = ({ title, data }) => {
 
   return (
     <div>
-      <canvas width={400} height={400} ref={chartRef} style={{maxWidth:"100vw"}} />
+      <canvas width={400} height={400} ref={chartRef} style={{maxWidth:'100vw'}} />
     </div>
   )
 }

--- a/packages/app/src/components/statistics/Doughnut.js
+++ b/packages/app/src/components/statistics/Doughnut.js
@@ -63,7 +63,7 @@ const Doughnut = ({ title, data }) => {
 
   return (
     <div>
-      <canvas width={400} height={400} ref={chartRef} />
+      <canvas width={400} height={400} ref={chartRef} style={{maxWidth:"100vw"}} />
     </div>
   )
 }

--- a/packages/app/src/components/statistics/Statistics.module.css
+++ b/packages/app/src/components/statistics/Statistics.module.css
@@ -1,9 +1,6 @@
 .view {
-  padding-left: 3em;
-  padding-right: 3em;
-  padding-top: 2em;
-  padding-bottom: 2em;
   margin: 2em;
+  max-width: 100vw;
 }
 
 .view > h1 {
@@ -19,6 +16,8 @@
   margin-bottom: 1.5em;
   display: flex;
   flex-wrap: wrap;
+  flex-direction: column;
+  align-items: center;
   justify-content: center;
   background-color: rgba(0, 0, 0, 0.5);
 }
@@ -29,4 +28,5 @@
   background-color: rgba(0, 0, 0, 0.4);
   padding: 1em;
   line-height: 1.1em;
+  margin: 1em 2em;
 }


### PR DESCRIPTION
Imposed max-width to divs to make the stats show more nicely on mobile screens.
- works nicely when opened on a small screen
- works nicely when scaling down from a big screen to small screen
- does not work as nicely when scaling up from a small screen to a big screen (the charts stay small)
